### PR TITLE
Add "Build masstree" stage to Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,13 @@ pipeline {
                 '''
             }
         }
+        stage ('Build masstree') {
+            steps {
+                sh '''
+                    ./bootstrap.sh
+                '''
+            }
+        }
         stage ('Build') {
             steps {
                 sh '''


### PR DESCRIPTION
Jenkinsのビルドパイプラインにmasstreeビルド用の `bootstrap.sh` の実行ステップを追加します。