### PR TITLE
remove non-public header reference

### DIFF
--- a/include/kvs/scheme.h
+++ b/include/kvs/scheme.h
@@ -15,8 +15,6 @@
 #include <memory>
 #include <vector>
 
-#include "include/debug.h"
-
 namespace kvs {
 
 /**


### PR DESCRIPTION
debug用ヘッダへの不要な参照が含まれておりビルドエラーになっていたので削除。