### PR TITLE
add log dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ HTML/
 *.a
 *.o
 src/kvs
+/log


### PR DESCRIPTION
プロジェクトルート直下のテスト用logディレクトリをgitコマンドが無視するよう.gitignoreに追加したいと思います。