### PR TITLE
add scan test simulating umikongo testcase

### DIFF
--- a/test/interface/simple_scan_test.cpp
+++ b/test/interface/simple_scan_test.cpp
@@ -200,6 +200,31 @@ TEST_F(simple_scan, scan_with_prefixed_end) {  // NOLINT
   ASSERT_EQ(Status::OK, leave(s));
 }
 
+TEST_F(simple_scan, scan_range_endpoint1) {  // NOLINT
+  // simulating 1st case in umikongo OperatorTest scan_pushdown_range
+  std::string r1("T200\x00\x80\x00\x00\xc7\x80\x00\x01\x91\x80\x00\x01\x2d\x80\x00\x00\x01", 21);                 // NOLINT
+  std::string r2("T200\x00\x80\x00\x00\xc8\x80\x00\x01\x92\x80\x00\x01\x2e\x80\x00\x00\x02", 21);                 // NOLINT
+  std::string r3("T200\x00\x80\x00\x00\xc8\x80\x00\x01\x93\x80\x00\x01\x2f\x80\x00\x00\x03", 21);                 // NOLINT
+  std::string r4("T200\x00\x80\x00\x00\xc8\x80\x00\x01\x94\x80\x00\x01\x30\x80\x00\x00\x04", 21);                 // NOLINT
+  std::string r5("T200\x00\x80\x00\x00\xc9\x80\x00\x01\x95\x80\x00\x01\x31\x80\x00\x00\x05", 21);                 // NOLINT
+  std::string  b("T200\x00\x80\x00\x00\xc8\x80\x00\x01\x93", 13);                 // NOLINT
+  std::string  e("T200\x00\x80\x00\x00\xc8\x80\x00\x01\x94", 13);                 // NOLINT
+  std::string v("bbb");  // NOLINT
+  Token s{};
+  ASSERT_EQ(Status::OK, enter(s));
+  ASSERT_EQ(Status::OK, upsert(s, r1, v));
+  ASSERT_EQ(Status::OK, upsert(s, r2, v));
+  ASSERT_EQ(Status::OK, upsert(s, r3, v));
+  ASSERT_EQ(Status::OK, upsert(s, r4, v));
+  ASSERT_EQ(Status::OK, upsert(s, r5, v));
+  ASSERT_EQ(Status::OK, commit(s));
+  std::vector<const Tuple*> records{};
+  ASSERT_EQ(Status::OK, scan_key(s, b, scan_endpoint::INCLUSIVE, e, scan_endpoint::EXCLUSIVE, records));
+  EXPECT_EQ(1, records.size());
+  ASSERT_EQ(Status::OK, commit(s));
+  ASSERT_EQ(Status::OK, leave(s));
+}
+
 TEST_F(simple_scan, open_scan_test) {  // NOLINT
     std::string k1("a");                 // NOLINT
     std::string v1("0");                 // NOLINT


### PR DESCRIPTION
umikongoのOperatorTest::scan_pushdown_rangeの１番目のテストケースをshirakamiで再現させたものです。