### PR TITLE
add delete storage at the end of testcase

### DIFF
--- a/test/concurrency_control/simple_upsert_test.cpp
+++ b/test/concurrency_control/simple_upsert_test.cpp
@@ -22,7 +22,10 @@ public:
         register_storage(st);
     }
 
-    void TearDown() override { fin(); }
+    void TearDown() override {
+        delete_storage(st);
+        fin();
+    }
 };
 
 TEST_F(simple_upsert, upsert) { // NOLINT


### PR DESCRIPTION
@thawk105 upsert実行後にdelete_storageすると、upsertで作ったオブジェクトがleakするようです。ちょっと見ていただいてもいいですか？

下記はPRをマージしてテスト実行時の再現ログです。
```
kuro@kurocom:~/git/shirakami/build/test$ ./shirakami-test_simple_upsert_test
Running main() from ../third_party/googletest/googletest/src/gtest_main.cc
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from simple_upsert
[ RUN      ] simple_upsert.upsert
[       OK ] simple_upsert.upsert (81 ms)
[ RUN      ] simple_upsert.double_upsert
[       OK ] simple_upsert.double_upsert (42 ms)
[----------] 2 tests from simple_upsert (123 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (123 ms total)
[  PASSED  ] 2 tests.

=================================================================
==2009==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7f87a445ab48 in operator new(unsigned long, std::align_val_t) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0b48)
    #1 0x7f87a4080f7d in shirakami::upsert(void*, unsigned long, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/concurrency_control/interface_update_insert.cpp:117
    #2 0x562426351312 in shirakami::testing::simple_upsert_upsert_Test::TestBody() ../test/concurrency_control/simple_upsert_test.cpp:38
    #3 0x7f87a3a138e7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #4 0x7f87a3a0166c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #5 0x7f87a39a1239 in testing::Test::Run() ../third_party/googletest/googletest/src/gtest.cc:2680
    #6 0x7f87a39a2680 in testing::TestInfo::Run() ../third_party/googletest/googletest/src/gtest.cc:2857
    #7 0x7f87a39a36bc in testing::TestSuite::Run() ../third_party/googletest/googletest/src/gtest.cc:3011
    #8 0x7f87a39c2230 in testing::internal::UnitTestImpl::RunAllTests() ../third_party/googletest/googletest/src/gtest.cc:5722
    #9 0x7f87a3a1680f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #10 0x7f87a3a0422d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #11 0x7f87a39bebe7 in testing::UnitTest::Run() ../third_party/googletest/googletest/src/gtest.cc:5305
    #12 0x7f87a3c86012 in RUN_ALL_TESTS() ../third_party/googletest/googletest/include/gtest/gtest.h:2486
    #13 0x7f87a3c85f58 in main ../third_party/googletest/googletest/src/gtest_main.cc:52
    #14 0x7f87a2f7fbf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)

Direct leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7f87a445ab48 in operator new(unsigned long, std::align_val_t) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0b48)
    #1 0x7f87a4080f7d in shirakami::upsert(void*, unsigned long, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/concurrency_control/interface_update_insert.cpp:117
    #2 0x5624263542e7 in shirakami::testing::simple_upsert_double_upsert_Test::TestBody() ../test/concurrency_control/simple_upsert_test.cpp:58
    #3 0x7f87a3a138e7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #4 0x7f87a3a0166c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #5 0x7f87a39a1239 in testing::Test::Run() ../third_party/googletest/googletest/src/gtest.cc:2680
    #6 0x7f87a39a2680 in testing::TestInfo::Run() ../third_party/googletest/googletest/src/gtest.cc:2857
    #7 0x7f87a39a36bc in testing::TestSuite::Run() ../third_party/googletest/googletest/src/gtest.cc:3011
    #8 0x7f87a39c2230 in testing::internal::UnitTestImpl::RunAllTests() ../third_party/googletest/googletest/src/gtest.cc:5722
    #9 0x7f87a3a1680f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #10 0x7f87a3a0422d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #11 0x7f87a39bebe7 in testing::UnitTest::Run() ../third_party/googletest/googletest/src/gtest.cc:5305
    #12 0x7f87a3c86012 in RUN_ALL_TESTS() ../third_party/googletest/googletest/include/gtest/gtest.h:2486
    #13 0x7f87a3c85f58 in main ../third_party/googletest/googletest/src/gtest_main.cc:52
    #14 0x7f87a2f7fbf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f87a445a448 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0448)
    #1 0x7f87a3fe7955 in std::_MakeUniq<shirakami::Tuple::Impl>::__single_object std::make_unique<shirakami::Tuple::Impl, std::basic_string_view<char, std::char_traits<char> >&, std::basic_string_view<char, std::char_traits<char> >&>(std::basic_string_view<char, std::char_traits<char> >&, std::basic_string_view<char, std::char_traits<char> >&) (/home/kuro/git/shirakami/build/src/libkvs.so+0x15f955)
    #2 0x7f87a3fe6f6c in shirakami::Tuple::Tuple(std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/tuple.cpp:148
    #3 0x7f87a403b0d7 in shirakami::Record::Record(std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/concurrency_control/include/record.h:21
    #4 0x7f87a4080ff7 in shirakami::upsert(void*, unsigned long, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/concurrency_control/interface_update_insert.cpp:117
    #5 0x562426351312 in shirakami::testing::simple_upsert_upsert_Test::TestBody() ../test/concurrency_control/simple_upsert_test.cpp:38
    #6 0x7f87a3a138e7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #7 0x7f87a3a0166c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #8 0x7f87a39a1239 in testing::Test::Run() ../third_party/googletest/googletest/src/gtest.cc:2680
    #9 0x7f87a39a2680 in testing::TestInfo::Run() ../third_party/googletest/googletest/src/gtest.cc:2857
    #10 0x7f87a39a36bc in testing::TestSuite::Run() ../third_party/googletest/googletest/src/gtest.cc:3011
    #11 0x7f87a39c2230 in testing::internal::UnitTestImpl::RunAllTests() ../third_party/googletest/googletest/src/gtest.cc:5722
    #12 0x7f87a3a1680f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #13 0x7f87a3a0422d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #14 0x7f87a39bebe7 in testing::UnitTest::Run() ../third_party/googletest/googletest/src/gtest.cc:5305
    #15 0x7f87a3c86012 in RUN_ALL_TESTS() ../third_party/googletest/googletest/include/gtest/gtest.h:2486
    #16 0x7f87a3c85f58 in main ../third_party/googletest/googletest/src/gtest_main.cc:52
    #17 0x7f87a2f7fbf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f87a445a448 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0448)
    #1 0x7f87a3fe7955 in std::_MakeUniq<shirakami::Tuple::Impl>::__single_object std::make_unique<shirakami::Tuple::Impl, std::basic_string_view<char, std::char_traits<char> >&, std::basic_string_view<char, std::char_traits<char> >&>(std::basic_string_view<char, std::char_traits<char> >&, std::basic_string_view<char, std::char_traits<char> >&) (/home/kuro/git/shirakami/build/src/libkvs.so+0x15f955)
    #2 0x7f87a3fe6f6c in shirakami::Tuple::Tuple(std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/tuple.cpp:148
    #3 0x7f87a403b0d7 in shirakami::Record::Record(std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/concurrency_control/include/record.h:21
    #4 0x7f87a4080ff7 in shirakami::upsert(void*, unsigned long, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >) ../src/concurrency_control/interface_update_insert.cpp:117
    #5 0x5624263542e7 in shirakami::testing::simple_upsert_double_upsert_Test::TestBody() ../test/concurrency_control/simple_upsert_test.cpp:58
    #6 0x7f87a3a138e7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #7 0x7f87a3a0166c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #8 0x7f87a39a1239 in testing::Test::Run() ../third_party/googletest/googletest/src/gtest.cc:2680
    #9 0x7f87a39a2680 in testing::TestInfo::Run() ../third_party/googletest/googletest/src/gtest.cc:2857
    #10 0x7f87a39a36bc in testing::TestSuite::Run() ../third_party/googletest/googletest/src/gtest.cc:3011
    #11 0x7f87a39c2230 in testing::internal::UnitTestImpl::RunAllTests() ../third_party/googletest/googletest/src/gtest.cc:5722
    #12 0x7f87a3a1680f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #13 0x7f87a3a0422d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #14 0x7f87a39bebe7 in testing::UnitTest::Run() ../third_party/googletest/googletest/src/gtest.cc:5305
    #15 0x7f87a3c86012 in RUN_ALL_TESTS() ../third_party/googletest/googletest/include/gtest/gtest.h:2486
    #16 0x7f87a3c85f58 in main ../third_party/googletest/googletest/src/gtest_main.cc:52
    #17 0x7f87a2f7fbf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f87a445a448 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0448)
    #1 0x7f87a3fe6d7f in shirakami::Tuple::Impl::set_value(char const*, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >**) ../src/tuple.cpp:140
    #2 0x7f87a4030723 in shirakami::write_phase(shirakami::session_info*, shirakami::tid_word const&, shirakami::tid_word const&, shirakami::commit_property) ../src/concurrency_control/interface_helper.cpp:310
    #3 0x7f87a4072712 in shirakami::commit(void*, shirakami::commit_param*) ../src/concurrency_control/interface_termination.cpp:98
    #4 0x56242635540d in shirakami::testing::simple_upsert_double_upsert_Test::TestBody() ../test/concurrency_control/simple_upsert_test.cpp:65
    #5 0x7f87a3a138e7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #6 0x7f87a3a0166c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #7 0x7f87a39a1239 in testing::Test::Run() ../third_party/googletest/googletest/src/gtest.cc:2680
    #8 0x7f87a39a2680 in testing::TestInfo::Run() ../third_party/googletest/googletest/src/gtest.cc:2857
    #9 0x7f87a39a36bc in testing::TestSuite::Run() ../third_party/googletest/googletest/src/gtest.cc:3011
    #10 0x7f87a39c2230 in testing::internal::UnitTestImpl::RunAllTests() ../third_party/googletest/googletest/src/gtest.cc:5722
    #11 0x7f87a3a1680f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #12 0x7f87a3a0422d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #13 0x7f87a39bebe7 in testing::UnitTest::Run() ../third_party/googletest/googletest/src/gtest.cc:5305
    #14 0x7f87a3c86012 in RUN_ALL_TESTS() ../third_party/googletest/googletest/include/gtest/gtest.h:2486
    #15 0x7f87a3c85f58 in main ../third_party/googletest/googletest/src/gtest_main.cc:52
    #16 0x7f87a2f7fbf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f87a445a448 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0448)
    #1 0x7f87a3fe6d7f in shirakami::Tuple::Impl::set_value(char const*, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >**) ../src/tuple.cpp:140
    #2 0x7f87a4030723 in shirakami::write_phase(shirakami::session_info*, shirakami::tid_word const&, shirakami::tid_word const&, shirakami::commit_property) ../src/concurrency_control/interface_helper.cpp:310
    #3 0x7f87a4072712 in shirakami::commit(void*, shirakami::commit_param*) ../src/concurrency_control/interface_termination.cpp:98
    #4 0x56242635209e in shirakami::testing::simple_upsert_upsert_Test::TestBody() ../test/concurrency_control/simple_upsert_test.cpp:43
    #5 0x7f87a3a138e7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #6 0x7f87a3a0166c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #7 0x7f87a39a1239 in testing::Test::Run() ../third_party/googletest/googletest/src/gtest.cc:2680
    #8 0x7f87a39a2680 in testing::TestInfo::Run() ../third_party/googletest/googletest/src/gtest.cc:2857
    #9 0x7f87a39a36bc in testing::TestSuite::Run() ../third_party/googletest/googletest/src/gtest.cc:3011
    #10 0x7f87a39c2230 in testing::internal::UnitTestImpl::RunAllTests() ../third_party/googletest/googletest/src/gtest.cc:5722
    #11 0x7f87a3a1680f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #12 0x7f87a3a0422d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #13 0x7f87a39bebe7 in testing::UnitTest::Run() ../third_party/googletest/googletest/src/gtest.cc:5305
    #14 0x7f87a3c86012 in RUN_ALL_TESTS() ../third_party/googletest/googletest/include/gtest/gtest.h:2486
    #15 0x7f87a3c85f58 in main ../third_party/googletest/googletest/src/gtest_main.cc:52
    #16 0x7f87a2f7fbf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)

SUMMARY: AddressSanitizer: 288 byte(s) leaked in 6 allocation(s).
```