### PR TITLE
SEGV with read-only scan

### DIFF
--- a/test/concurrency_control/readonly_transaction_test.cpp
+++ b/test/concurrency_control/readonly_transaction_test.cpp
@@ -1,0 +1,55 @@
+#include <bitset>
+#include <thread>
+
+#include "gtest/gtest.h"
+
+// shirakami-impl interface library
+#include "tuple_local.h"
+
+#ifdef CPR
+#include "fault_tolerance/include/cpr.h"
+#endif
+#include "shirakami/interface.h"
+namespace shirakami::testing {
+
+using namespace shirakami;
+using namespace std::chrono_literals;
+
+Storage storage;
+
+class readonly_transaction_test : public ::testing::Test { // NOLINT
+public:
+    void SetUp() override { init(); } // NOLINT
+
+    void TearDown() override { fin(); }
+};
+
+TEST_F(readonly_transaction_test, readonly_scan) { // NOLINT
+    register_storage(storage);
+    std::string k{"k"};   // NOLINT
+    std::string v{"v"};     // NOLINT
+    Token s{};
+    ASSERT_EQ(Status::OK, enter(s));
+    ScanHandle handle{};
+    ASSERT_EQ(Status::OK, insert(s, storage, k, v));
+    ASSERT_EQ(Status::OK, commit(s)); // NOLINT
+
+    // trying to wait enough
+#ifdef CPR
+    shirakami::cpr::wait_next_checkpoint();
+#endif
+    std::this_thread::sleep_for(3s);
+#ifdef CPR
+    shirakami::cpr::wait_next_checkpoint();
+#endif
+
+    tx_begin(s, true);
+    ASSERT_EQ(Status::OK, open_scan(s, storage, "", scan_endpoint::INF, "", scan_endpoint::INF, handle));
+    Tuple* tuple{};
+    ASSERT_EQ(Status::OK, read_from_scan(s, handle, &tuple));
+    ASSERT_EQ(Status::WARN_SCAN_LIMIT, read_from_scan(s, handle, &tuple));
+    ASSERT_EQ(Status::OK, commit(s)); // NOLINT
+    ASSERT_EQ(leave(s), Status::OK);
+}
+
+} // namespace shirakami::testing


### PR DESCRIPTION
tx_beginでreadonly=trueを指定した場合にread_from_scanでSEGVに遭遇しました。
-DBUILD_CPR=ON/OFFにかかわらず起きている模様です。
本PRをマージしてテスト実行した場合のログを添付します。
```
kuro@kurocom:~/git/shirakami/build/test$ ./shirakami-test_readonly_transaction_test
Running main() from ../third_party/googletest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from readonly_transaction_test
[ RUN      ] readonly_transaction_test.readonly_scan
ASAN:DEADLYSIGNAL
=================================================================
==6902==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7fbf618db7de bp 0x7ffe242101e0 sp 0x7ffe24210140 T0)
==6902==The signal is caused by a READ memory access.
==6902==Hint: address points to the zero page.
    #0 0x7fbf618db7dd in std::atomic<yakushima::node_version64_body>::load(std::memory_order) const /usr/include/c++/7/atomic:250
    #1 0x7fbf618c959a in yakushima::node_version64::get_body() const ../third_party/yakushima/include/version.h:306
    #2 0x7fbf618c99c0 in yakushima::node_version64::get_stable_version() const ../third_party/yakushima/include/version.h:327
    #3 0x7fbf619b8d4d in shirakami::read_from_scan(void*, unsigned long, shirakami::Tuple**) ../src/concurrency_control/interface_scan.cpp:121
    #4 0x55de2092a99f in shirakami::testing::readonly_transaction_test_readonly_scan_Test::TestBody() ../test/concurrency_control/readonly_transaction_test.cpp:49
    #5 0x7fbf612b48e7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #6 0x7fbf612a266c in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #7 0x7fbf61242239 in testing::Test::Run() ../third_party/googletest/googletest/src/gtest.cc:2680
    #8 0x7fbf61243680 in testing::TestInfo::Run() ../third_party/googletest/googletest/src/gtest.cc:2857
    #9 0x7fbf612446bc in testing::TestSuite::Run() ../third_party/googletest/googletest/src/gtest.cc:3011
    #10 0x7fbf61263230 in testing::internal::UnitTestImpl::RunAllTests() ../third_party/googletest/googletest/src/gtest.cc:5722
    #11 0x7fbf612b780f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2605
    #12 0x7fbf612a522d in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../third_party/googletest/googletest/src/gtest.cc:2641
    #13 0x7fbf6125fbe7 in testing::UnitTest::Run() ../third_party/googletest/googletest/src/gtest.cc:5305
    #14 0x7fbf61527012 in RUN_ALL_TESTS() ../third_party/googletest/googletest/include/gtest/gtest.h:2486
    #15 0x7fbf61526f58 in main ../third_party/googletest/googletest/src/gtest_main.cc:52
    #16 0x7fbf60601bf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)
    #17 0x55de20927889 in _start (/home/kuro/git/shirakami/build/test/shirakami-test_readonly_transaction_test+0x42889)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /usr/include/c++/7/atomic:250 in std::atomic<yakushima::node_version64_body>::load(std::memory_order) const
==6902==ABORTING
```