### PR TITLE
Fix slow completion for each testcase

### DIFF
--- a/src/include/logger.h
+++ b/src/include/logger.h
@@ -15,8 +15,8 @@
 
 namespace shirakami::logger {
 
-static inline auto loggersink = std::make_shared<spdlog::sinks::stdout_sink_mt>();                                  // NOLINT
-static inline auto shirakami_logger = std::make_shared<spdlog::async_logger>("shirakami_logger", loggersink, 8192); // NOLINT
+inline auto loggersink = std::make_shared<spdlog::sinks::stdout_sink_mt>();                                  // NOLINT
+inline auto shirakami_logger = std::make_shared<spdlog::async_logger>("shirakami_logger", loggersink, 8192); // NOLINT
 
 static inline void setup_spdlog() {
 


### PR DESCRIPTION
下記のようにテストケースのプロセスに終了するのに時間がかかる状況が観察されていた。(テストケース153msに対して完了6.7s)

```
kuro@kuronote:~/git/shirakami/build$ time test/shirakami-test_tid_test 
Running main() from ../third_party/googletest/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from tid_test
[ RUN      ] tid_test.tidword
[       OK ] tid_test.tidword (153 ms)
[----------] 1 test from tid_test (153 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (153 ms total)
[  PASSED  ] 1 test.

real	0m6.731s
user	0m0.094s
sys	0m0.169s

```

原因はlogger.hにあるshirakami_logger変数が内部リンケージだったため。意図せず翻訳単位ごとにloggerのインスタンスが生成されてしまっていた。spdlog::async_loggerはインスタンスごとにスレッドを生成するという仕様であり、このスレッドの終了に時間がかかっていた。
