### PR TITLE
Disable CI build on ubuntu-18.04

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-tag: [ubuntu-18.04, ubuntu-20.04]
+        container-tag: [ubuntu-20.04]
     runs-on: [self-hosted, docker]
     timeout-minutes: 30
     container:


### PR DESCRIPTION
Disable Ubuntu 18.04 from the CI build matrix.