### PR TITLE
add missing includes (for FTBFS with gcc-10)

### DIFF
--- a/include/shirakami/result_info.h
+++ b/include/shirakami/result_info.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdlib>
+#include <string>
 #include <string_view>
 
 #include "storage_options.h"


### PR DESCRIPTION
`#include` が足りていない箇所があり、
g++10 では `std::abort()`, `std::string` の参照でコンパイルエラーになりました。

g++9 では、include している別の system library から孫 include されているため、省略しても通っていたようです。
例えば `#include <array>` とすると、
g++9 では /usr/include/c++/9/array →  `stdexcept` → `string` が include されますが、
g++10 では /usr/include/c++/10/array から `stdexcept` が include されないため、 `string` も include されないといった違いがあります。