### PR TITLE
add -fsized-deallocation compiler flag for clang++

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -47,6 +47,10 @@ endif ()
 
 cmake_host_system_information(RESULT cores QUERY NUMBER_OF_LOGICAL_CORES)
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|AppleClang)$")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsized-deallocation")
+endif ()
+
 # about index
 add_definitions(-DINDEX_YAKUSHIMA)
 add_definitions(-DYAKUSHIMA_EPOCH_TIME=40)


### PR DESCRIPTION
yakushima で使われている、サイズを取る `delete` を clang++ で扱うには、コンパイラにフラグの指定が必要なため、その対応です。

関連Issue: https://github.com/project-tsurugi/tsurugi-issues/issues/273 