### PR TITLE
fix memory_order for load

### DIFF
--- a/src/concurrency_control/include/local_set.h
+++ b/src/concurrency_control/include/local_set.h
@@ -165,7 +165,7 @@ public:
     Status erase(write_set_obj* wso);
 
     [[nodiscard]] bool get_for_batch() const {
-        return for_batch_.load(std::memory_order_acq_rel);
+        return for_batch_.load(std::memory_order_acquire);
     }
 
     std::shared_mutex& get_mtx() { return mtx_; }


### PR DESCRIPTION
load に対して memory_order_acq_rel が指定されていたのを見つたので修正です。
最近混入した誤りのようです。