### PR TITLE
add TSURUGI_FAST_SHUTDOWN build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static" ON)
 option(BUILD_PWAL "Build parallel write ahead logging as logging." ON)
 option(PWAL_ENABLE_READ_LOG "PWAL log read (/ write) informations to verify whether committed schedule is valid." OFF)
 
+# shutdown shortcut
+option(TSURUGI_FAST_SHUTDOWN "enable shortcuts during shutdown process by default" OFF)
+
 # benchmark
 option(BUILD_ROCKSDB_BENCH "Build rocksdb benchmark." OFF)
 

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -78,6 +78,11 @@ else ()
     message("It uses no logging method.")
 endif ()
 
+if (TSURUGI_FAST_SHUTDOWN)
+    add_definitions(-DTSURUGI_FAST_SHUTDOWN_ON)
+    message("shutdown shortcut is enabled by default.")
+endif ()
+
 # Begin : parameter settings
 
 # Begin : about kvs

--- a/src/concurrency_control/interface/shut_down.cpp
+++ b/src/concurrency_control/interface/shut_down.cpp
@@ -44,6 +44,20 @@
 
 namespace shirakami {
 
+static inline bool is_fast_shutdown() {
+    // check environ "TSURUGI_FAST_SHUTDOWN" first
+    if (auto* fast_shutdown_envstr = std::getenv("TSURUGI_FAST_SHUTDOWN");
+        fast_shutdown_envstr != nullptr && *fast_shutdown_envstr != '\0') {
+        return std::strcmp(fast_shutdown_envstr, "1") == 0;
+    }
+    // use default value from build parameter
+#if defined(TSURUGI_FAST_SHUTDOWN_ON)
+    return true;
+#else
+    return false;
+#endif
+}
+
 void fin([[maybe_unused]] bool force_shut_down_logging) try {
     if (!get_initialized()) { return; }
     // set flag
@@ -108,9 +122,7 @@ void fin([[maybe_unused]] bool force_shut_down_logging) try {
 #endif
     VLOG(log_debug_timing_event) << log_location_prefix_timing_event
                                  << "shutdown:start_delete_all_records";
-    auto* fast_shutdown_envstr = std::getenv("TSURUGI_FAST_SHUTDOWN");
-    bool fast_shutdown = fast_shutdown_envstr != nullptr &&
-                         std::strcmp(fast_shutdown_envstr, "1") == 0;
+    bool fast_shutdown = is_fast_shutdown();
     if (fast_shutdown) {
         LOG(INFO) << log_location_prefix << "skipped delete_all_records";
     } else {


### PR DESCRIPTION
シャットダウン動作の一部を飛ばして高速化する機能(以下「短絡化」)について、
環境変数 `TSURUGI_FAST_SHUTDOWN` が `1` に設定されていた場合に有効化する
としていましたが、以下のように変更します。

* 環境変数 `TSURUGI_FAST_SHUTDOWN` が `1` に設定されていた場合 → 短絡化有効
* 環境変数 `TSURUGI_FAST_SHUTDOWN` が空文字列でなく、`1` 以外の値に設定されていた場合 → 短絡化無効
* 環境変数 `TSURUGI_FAST_SHUTDOWN` が未設定もしくは空文字列 → ビルド時指定の規定値を使用する

ビルド時指定の規定値
* `-DTSURUGI_FAST_SHUTDOWN=ON` → ビルド時指定の規定値を「短絡化有効」とする 
* `-DTSURUGI_FAST_SHUTDOWN=OFF` → ビルド時指定の規定値を「短絡化無効」とする 
* `-DTSURUGI_FAST_SHUTDOWN` の指定なし → ビルド時指定の規定値を「短絡化無効」とする (`OFF` の時と同じ) 

案件: project-tsurugi/tsurugi-issues#189