### PR TITLE
add feature to switch the waiting-bypass mode by environ

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -68,7 +68,7 @@ jobs:
           ASAN_OPTIONS: detect_stack_use_after_return=true
         run: |
           cd build-pwal
-          SHIRAKAMI_DISABLE_WAITING_BYPASS=1 ctest --verbose --timeout 200 -j 20
+          SHIRAKAMI_ENABLE_WAITING_BYPASS=0 ctest --verbose --timeout 200 -j 20
 
       - name: Verify
         uses: project-tsurugi/tsurugi-annotations-action@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -62,6 +62,14 @@ jobs:
           cd build-pwal
           ctest --verbose --timeout 200 -j 20
 
+      - name: CTest_with_PWAL_without_BYPASS
+        env:
+          GTEST_OUTPUT: xml
+          ASAN_OPTIONS: detect_stack_use_after_return=true
+        run: |
+          cd build-pwal
+          SHIRAKAMI_DISABLE_WAITING_BYPASS=1 ctest --verbose --timeout 200 -j 20
+
       - name: Verify
         uses: project-tsurugi/tsurugi-annotations-action@v1
         if: always()

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -7,9 +7,15 @@ Shirakami コードから参照する環境変数の説明
 ## 開発者向け動作フラグ
 
 * `SHIRAKAMI_ENABLE_WAITING_BYPASS`
-  * waiting bypass 実行に関するフラグ。未指定時には、waiting bypass を実行する。
-  * `SHIRAKAMI_ENABLE_WAITING_BYPASS=0` とすると、waiting bypass を実行しなくなる。
+  * waiting bypass 実行に関するフラグ。実行するかしないかを選択する。
+  * デフォルト動作は waiting bypass を実行する。
+    * 未指定時、空文字列指定時には、デフォルト動作をする。
+    * `SHIRAKAMI_ENABLE_WAITING_BYPASS=0` とすると、waiting bypass を実行しない。
+    * `SHIRAKAMI_ENABLE_WAITING_BYPASS=1` とすると、waiting bypass を実行する。
 
 * `SHIRAKAMI_WAITING_BYPASS_TO_ROOT`
-  * waiting bypass 実行時の動作に関するフラグ。未指定時には root を追い越さない waiting bypass モードで実行する。
-  * `SHIRAKAMI_WAITING_BYPASS_TO_ROOT=1` とすると root を追い越すモードで実行する。
+  * waiting bypass 実行時の root を追い越す動作モードに関するフラグ。root を追い越すか追い越さないかを選択する。
+  * デフォルト動作は root を追い越さないモードで実行する。
+    * 未指定時、空文字列指定時には、デフォルト動作をする。
+    * `SHIRAKAMI_WAITING_BYPASS_TO_ROOT=0` とすると root を追い越さないモードで実行する。
+    * `SHIRAKAMI_WAITING_BYPASS_TO_ROOT=1` とすると root を追い越すモードで実行する。

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -1,0 +1,15 @@
+# 参照する環境変数
+
+## この文書について
+
+Shirakami コードから参照する環境変数の説明
+
+## 開発者向け動作フラグ
+
+* `SHIRAKAMI_ENABLE_WAITING_BYPASS`
+  * waiting bypass 実行に関するフラグ。未指定時には、waiting bypass を実行する。
+  * `SHIRAKAMI_ENABLE_WAITING_BYPASS=0` とすると、waiting bypass を実行しなくなる。
+
+* `SHIRAKAMI_WAITING_BYPASS_TO_ROOT`
+  * waiting bypass 実行時の動作に関するフラグ。未指定時には root を追い越さない waiting bypass モードで実行する。
+  * `SHIRAKAMI_WAITING_BYPASS_TO_ROOT=1` とすると root を追い越すモードで実行する。

--- a/src/concurrency_control/include/ongoing_tx.h
+++ b/src/concurrency_control/include/ongoing_tx.h
@@ -89,6 +89,10 @@ public:
      */
     static void set_optflags();
 
+    static bool get_optflag_disable_waiting_bypass() {
+        return optflag_disable_waiting_bypass_;
+    }
+
 private:
     /**
      * @brief This is mutex for tx_info_;
@@ -107,11 +111,11 @@ private:
     /**
      * @brief enable/disable waiting bypass.
      */
-    static inline bool optflag_disable_waiting_bypass_;  // NOLINT
+    static inline bool optflag_disable_waiting_bypass_; // NOLINT
     /**
      * @brief waiting bypass to root (aggressive optimization).
      */
-    static inline bool optflag_waiting_bypass_to_root_;  // NOLINT
+    static inline bool optflag_waiting_bypass_to_root_; // NOLINT
 };
 
 } // namespace shirakami

--- a/src/concurrency_control/include/ongoing_tx.h
+++ b/src/concurrency_control/include/ongoing_tx.h
@@ -84,6 +84,11 @@ public:
     */
     static Status waiting_bypass(session* ti);
 
+    /**
+     * @brief set optimization flags from environ
+     */
+    static void set_optflags();
+
 private:
     /**
      * @brief This is mutex for tx_info_;
@@ -99,6 +104,14 @@ private:
      * used by them for read_by gc.
      */
     static inline std::atomic<epoch::epoch_t> lowest_epoch_{0}; // NOLINT
+    /**
+     * @brief enable/disable waiting bypass.
+     */
+    static inline bool optflag_disable_waiting_bypass_;  // NOLINT
+    /**
+     * @brief waiting bypass to root (aggressive optimization).
+     */
+    static inline bool optflag_waiting_bypass_to_root_;  // NOLINT
 };
 
 } // namespace shirakami

--- a/src/concurrency_control/interface/start_up.cpp
+++ b/src/concurrency_control/interface/start_up.cpp
@@ -13,6 +13,7 @@
 #include "concurrency_control/bg_work/include/bg_commit.h"
 #include "concurrency_control/include/epoch.h"
 #include "concurrency_control/include/epoch_internal.h"
+#include "concurrency_control/include/ongoing_tx.h"
 #include "concurrency_control/include/read_plan.h"
 #include "concurrency_control/include/session.h"
 #include "concurrency_control/include/tuple_local.h"
@@ -210,6 +211,8 @@ Status init_body(database_options options) { // NOLINT
 
     // about read area
     read_plan::init();
+
+    ongoing_tx::set_optflags();
 
     set_initialized(true); // about init command
     return Status::OK;

--- a/src/concurrency_control/ongoing_tx.cpp
+++ b/src/concurrency_control/ongoing_tx.cpp
@@ -293,6 +293,8 @@ void ongoing_tx::set_optflags() {
         envstr != nullptr && *envstr != '\0') {
         is_envset = (std::strcmp(envstr, "1") == 0);
     }
+    VLOG(log_debug) << log_location_prefix << "optflag: waiting bypass is "
+                    << (!is_envset ? "enabled" : "disabled");
     optflag_disable_waiting_bypass_ = is_envset;
     // check environ "SHIRAKAMI_WAITING_BYPASS_TO_ROOT"
     is_envset = false;
@@ -301,6 +303,8 @@ void ongoing_tx::set_optflags() {
         is_envset = (std::strcmp(envstr, "1") == 0);
     }
     optflag_waiting_bypass_to_root_ = is_envset;
+    VLOG(log_debug) << log_location_prefix << "optflag: bypass to root "
+                    << (is_envset ? "on" : "off");
 }
 
 } // namespace shirakami

--- a/src/concurrency_control/ongoing_tx.cpp
+++ b/src/concurrency_control/ongoing_tx.cpp
@@ -4,6 +4,8 @@
 #include "concurrency_control/include/wp.h"
 #include "concurrency_control/interface/long_tx/include/long_tx.h"
 
+#include "database/include/logging.h"
+
 namespace shirakami {
 
 bool ongoing_tx::exist_id(std::size_t id) {
@@ -40,7 +42,8 @@ Status ongoing_tx::waiting_bypass(session* ti) {
             auto* token = std::get<ongoing_tx::index_session>(elem);
 
             // check exist living wait for, for not to remove path to root.
-            if (!optflag_waiting_bypass_to_root_ && !exist_living_wait_for(token)) {
+            if (!optflag_waiting_bypass_to_root_ &&
+                !exist_living_wait_for(token)) {
                 // not bypass for tree root
                 continue;
             }
@@ -197,12 +200,8 @@ bool ongoing_tx::exist_wait_for(session* ti, Status& out_status) {
                          * ルートになるまでパスを縮めてはいけない。
                          */
                         bool do_waiting_bypass_here =
-                            // if disabled -> false
-                            !optflag_disable_waiting_bypass_ &&
-                            // if to_root -> true
-                            (optflag_waiting_bypass_to_root_ ||
-                             // check size>2 (not to root)
-                             wait_for.size() > 2);
+                                // if disabled -> false
+                                !optflag_disable_waiting_bypass_;
                         if (do_waiting_bypass_here) {
                             out_status = waiting_bypass(ti);
                         }

--- a/src/concurrency_control/ongoing_tx.cpp
+++ b/src/concurrency_control/ongoing_tx.cpp
@@ -287,17 +287,18 @@ void ongoing_tx::remove_id(std::size_t const id) {
 }
 
 void ongoing_tx::set_optflags() {
-    // check environ "SHIRAKAMI_DISABLE_WAITING_BYPASS"
-    bool is_envset = false;
-    if (auto* envstr = std::getenv("SHIRAKAMI_DISABLE_WAITING_BYPASS");
+    // check environ "SHIRAKAMI_ENABLE_WAITING_BYPASS"
+    // disabled only if set "SHIRAKAMI_ENABLE_WAITING_BYPASS=0"
+    bool enable_wb = true;
+    if (auto* envstr = std::getenv("SHIRAKAMI_ENABLE_WAITING_BYPASS");
         envstr != nullptr && *envstr != '\0') {
-        is_envset = (std::strcmp(envstr, "1") == 0);
+        enable_wb = (std::strcmp(envstr, "0") != 0);
     }
     VLOG(log_debug) << log_location_prefix << "optflag: waiting bypass is "
-                    << (!is_envset ? "enabled" : "disabled");
-    optflag_disable_waiting_bypass_ = is_envset;
+                    << (enable_wb ? "enabled (default)" : "disabled");
+    optflag_disable_waiting_bypass_ = !enable_wb;
     // check environ "SHIRAKAMI_WAITING_BYPASS_TO_ROOT"
-    is_envset = false;
+    bool is_envset = false;
     if (auto* envstr = std::getenv("SHIRAKAMI_WAITING_BYPASS_TO_ROOT");
         envstr != nullptr && *envstr != '\0') {
         is_envset = (std::strcmp(envstr, "1") == 0);

--- a/test/concurrency_control/complicated/tsurugi_issue556_test.cpp
+++ b/test/concurrency_control/complicated/tsurugi_issue556_test.cpp
@@ -1,0 +1,143 @@
+
+#include "concurrency_control/include/ongoing_tx.h"
+#include "concurrency_control/include/session.h"
+
+#include "database/include/logging.h"
+
+#include "shirakami/interface.h"
+
+#include "index/yakushima/include/interface.h"
+
+#include "test_tool.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+
+using namespace shirakami;
+using transaction_type = shirakami::transaction_options::transaction_type;
+
+#define ASSERT_OK(expr) ASSERT_EQ(expr, shirakami::Status::OK)
+
+namespace shirakami::testing {
+
+class tsurugi_issue556_test : public ::testing::Test {
+public:
+    static void call_once_f() {
+        google::InitGoogleLogging("shirakami-test-concurrency_control-"
+                                  "complicated-tsurugi_issue556_test");
+        // FLAGS_stderrthreshold = 0;
+    }
+
+    void SetUp() override {
+        std::call_once(init_, call_once_f);
+        init(); // NOLINT
+    }
+
+    void TearDown() override { fin(); }
+
+private:
+    static inline std::once_flag init_; // NOLINT
+};
+
+TEST_F(tsurugi_issue556_test, test) { // NOLINT
+    // prepare storage
+    Storage st1{};
+    Storage st2{};
+    ASSERT_OK(create_storage("A", st1));
+    ASSERT_OK(create_storage("B", st2));
+
+    // prepare session
+    Token s1{};
+    Token s2{};
+    Token s3{};
+    /**
+     * wp st1
+    */
+    ASSERT_OK(enter(s1));
+     /**
+      * read st1,2, wp st2, finally no conflict with s1, but bypassed by s3
+     */
+    ASSERT_OK(enter(s2));
+    /**
+     * read st2, wait for s2 bypass s2 to s1. same at s1, wp and write st2, 
+     * read wait s2, s2 read st2, commit s3 try. wp and write st2 but s2 read 
+     * st2 at future
+    */
+    ASSERT_OK(enter(s3));
+
+    // prepare t0
+    ASSERT_OK(tx_begin({s1, transaction_type::SHORT}));
+    ASSERT_OK(upsert(s1, st1, "0", ""));
+    ASSERT_OK(upsert(s1, st1, "1", ""));
+    ASSERT_OK(upsert(s1, st2, "0", ""));
+    ASSERT_OK(commit(s1));
+
+    // test
+    ASSERT_OK(tx_begin({s1, transaction_type::LONG, {st1}}));
+    wait_epoch_update();
+    ASSERT_OK(tx_begin({s2, transaction_type::LONG, {st2}}));
+    wait_epoch_update();
+    ASSERT_OK(tx_begin({s3, transaction_type::LONG, {st2}}));
+    wait_epoch_update();
+
+    // s2 read st1 (without conflict),2 chain
+    std::string buf{};
+    ASSERT_OK(search_key(s2, st1, "1", buf));
+    ASSERT_OK(search_key(s2, st2, "0", buf));
+    // s3 read st2, chain
+    ASSERT_OK(search_key(s3, st2, "0", buf));
+
+    // s3 write st2
+    ASSERT_OK(upsert(s3, st2, "0", ""));
+
+    // s4 commit, boundary wait for s1,2,3 but will bypass 2,3.
+    // read wait for s1,2,3, will (can) not bypass
+    std::atomic<Status> cb_rc{};
+    std::atomic<bool> was_called{false};
+    auto cb = [&cb_rc,
+               &was_called](Status rs, [[maybe_unused]] reason_code rc,
+                            [[maybe_unused]] durability_marker_type dm) {
+        cb_rc.store(rs, std::memory_order_release);
+        was_called.store(true, std::memory_order_release);
+    };
+
+    ASSERT_FALSE(commit(s3, cb));
+    // sleep for coming waiting bypass
+    sleep(1); // it may need more depending on environment.
+    // boundary wait is expected to skip 2,3, but read wait for s1,2,3
+    // for s1 boundary, need conflict between s1 and s4
+
+    // s1 write st1 ""
+    ASSERT_OK(upsert(s1, st1, "0", "")); // make conflict between s1 and s3
+    ASSERT_OK(commit(s1));
+
+    // s2 commit without write, so chain between s2, s3 can be treated as invalid.
+    ASSERT_OK(commit(s2));
+
+    // now, s3 bypass 2 and same at s1. read wait can release. wait for commit
+    while (!was_called) { _mm_pause(); }
+
+    if (ongoing_tx::get_optflag_disable_waiting_bypass()) {
+        LOG(INFO) << "disabled wb";
+        /**
+         * if no waiting bypass, 3 didn't conflict 2. 3 conflict 1 but 3 don't
+         * break 1's read.
+        */
+       ASSERT_OK(cb_rc); 
+    } else {
+        LOG(INFO) << "enabled wb";
+        /**
+         * if waiting bypass, 3 didn't conflict 2 but bypass 2. 3 conflict 1 
+         * but 3 don't break 1's read. however, bypassed 3's write break 2's 
+         * read (st2, "0"). so 3 fail.
+        */
+       ASSERT_EQ(cb_rc, Status::ERR_CC); 
+    }
+
+    ASSERT_OK(leave(s1));
+    ASSERT_OK(leave(s2));
+    ASSERT_OK(leave(s3));
+}
+
+} // namespace shirakami::testing


### PR DESCRIPTION
環境変数 `SHIRAKAMI_DISABLE_WAITING_BYPASS` が `1` に設定されていた場合に
waiting bypass を無効化する(全くしなくする)修正です。
また、waiting bypass を無効されていない場合には `SHIRAKAMI_WAITING_BYPASS_TO_ROOT` が `1` に設定されていた場合には 1.0.0 BETA2 以前の waiting bypass の挙動 (root まで bypass する) をするようにします。

これらにより、waiting bypass の効果測定・挙動検証をしやすくします。

案件: https://github.com/project-tsurugi/tsurugi-issues/issues/556

@thawk105 `SHIRAKAMI_DISABLE_WAITING_BYPASS` (waiting bypass 無効) のオンオフが効いていることの確認テストを追加していただきましたが、もし可能であれば、さらに加えて `SHIRAKAMI_WAITING_BYPASS_TO_ROOT` (root まで bypass する) のオンオフが効いていることの確認テストも追加していただけたらと思います。
