### PR TITLE
fix: timing of ltx session state check in the bg_commit worker loop

### DIFF
--- a/src/concurrency_control/bg_work/bg_commit.cpp
+++ b/src/concurrency_control/bg_work/bg_commit.cpp
@@ -114,8 +114,9 @@ void bg_commit::worker() {
                     !ti->get_requested_commit()) {
                     // not long or not requested commit.
                     LOG(ERROR) << log_location_prefix << "unexpected error. "
-                               << ti->get_tx_type() << ", "
-                               << ti->get_requested_commit();
+                               << ti->get_tx_type() << ", " << std::boolalpha
+                               << ti->get_requested_commit() << ", tx_id:"
+                               << tx_id;
                     return;
                 }
                 used_ids().insert(tx_id);

--- a/src/concurrency_control/bg_work/bg_commit.cpp
+++ b/src/concurrency_control/bg_work/bg_commit.cpp
@@ -92,16 +92,6 @@ void bg_commit::worker() {
             token = std::get<1>(*itr);
             tx_id = std::get<0>(*itr);
             ti = static_cast<session*>(token);
-            // check from long
-            if (ti->get_tx_type() !=
-                        transaction_options::transaction_type::LONG ||
-                !ti->get_requested_commit()) {
-                // not long or not requested commit.
-                LOG(ERROR) << log_location_prefix << "unexpected error. "
-                           << ti->get_tx_type() << ", "
-                           << ti->get_requested_commit();
-                return;
-            }
 
             // check conflict between worker
             {
@@ -118,6 +108,16 @@ void bg_commit::worker() {
                     // found
                     continue;
                 } // not found, not currently used and not checked
+                // check from long
+                if (ti->get_tx_type() !=
+                            transaction_options::transaction_type::LONG ||
+                    !ti->get_requested_commit()) {
+                    // not long or not requested commit.
+                    LOG(ERROR) << log_location_prefix << "unexpected error. "
+                               << ti->get_tx_type() << ", "
+                               << ti->get_requested_commit();
+                    return;
+                }
                 used_ids().insert(tx_id);
                 checked_ids.insert(tx_id);
                 break;


### PR DESCRIPTION
bg_commit worker が掴んだ LTX session の状態をチェックしますが、
ほかの worker スレッドが既に掴んでいたため自分で commit 処理する対象から除外するものもチェックしてしまうので、
想定しない session 状態に遭遇して異常終了することが多くなっている問題を修正するものです。
(状態チェックする場所を、ほかの worker スレッドが既に掴んでいるかのチェック後に移動する)

案件: https://github.com/project-tsurugi/tsurugi-issues/issues/367