### PR TITLE
ci: parallelized test steps on build matrix

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
+        test-group: [default, labels]
     runs-on: [self-hosted, docker]
     permissions:
       checks: write
@@ -32,43 +33,47 @@ jobs:
       - name: Install_Dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: CMake_Build_with_PWAL
+      - name: CMake_Build
         run: |
-          mkdir -p build-pwal
-          cd build-pwal
+          mkdir -p build
+          cd build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DBUILD_PWAL=ON ..
           cmake --build . --target all --clean-first
 
       - name: CTest_total
+        if: matrix.test-group == 'default'
         env:
           GTEST_OUTPUT: xml
           ASAN_OPTIONS: detect_stack_use_after_return=true
         run: |
-          cd build-pwal
+          cd build
           ctest --verbose --timeout 200 -j 20
 
       - name: CTest_CC
+        if: matrix.test-group == 'labels'
         env:
           GTEST_OUTPUT: xml
           ASAN_OPTIONS: detect_stack_use_after_return=true
         run: |
-          cd build-pwal
+          cd build
           ctest --verbose --timeout 200 -j 20 -L CC
 
       - name: CTest_LOGGING
+        if: matrix.test-group == 'labels'
         env:
           GTEST_OUTPUT: xml
           ASAN_OPTIONS: detect_stack_use_after_return=true
         run: |
-          cd build-pwal
+          cd build
           ctest --verbose --timeout 200 -j 20 -L LOGGING
 
       - name: CTest_WAITING_BYPASS
+        if: matrix.test-group == 'labels'
         env:
           GTEST_OUTPUT: xml
           ASAN_OPTIONS: detect_stack_use_after_return=true
         run: |
-          cd build-pwal
+          cd build
           SHIRAKAMI_ENABLE_WAITING_BYPASS=0 ctest --verbose --timeout 200 -j 20 -L WAITING_BYPASS
           SHIRAKAMI_ENABLE_WAITING_BYPASS=1 ctest --verbose --timeout 200 -j 20 -L WAITING_BYPASS
 


### PR DESCRIPTION
CIワークフローに対して、ビルドマトリックス上でTest関連のstepを並列化して実行します。

現状4つのTest関連stepがあるのでこれをすべて並列に実行するワークフローとすることも可能でしたが、現状 CTest_LOGGING と CTest_WAITING_BYPASS の実行時間は数秒であり並列化のオーバーヘッドが勝ってしまうため、default(テストラベルの指定なし)とテストラベル付き、の2つのグループに分けるにとどめました。

今後テストが追加され、ビルドマトリックス間での実行時間に偏りが発生したら都度調整していけばよいかと思います。
