### PR TITLE
bg_commit worker の commit 試行削減を目的とする変更

### DIFF
--- a/src/concurrency_control/bg_work/bg_commit.cpp
+++ b/src/concurrency_control/bg_work/bg_commit.cpp
@@ -61,7 +61,7 @@ void bg_commit::register_tx(Token token) {
     {
         std::lock_guard<std::shared_mutex> lk_{mtx_cont_wait_tx()};
         auto ret = cont_wait_tx().insert(
-                std::make_tuple(ti->get_long_tx_id(), token));
+                std::make_pair(ti->get_long_tx_id(), token));
         if (!ret.second) {
             // already exist
             LOG_FIRST_N(ERROR, 1) << log_location_prefix << "library programming error";
@@ -159,7 +159,7 @@ void bg_commit::worker() {
         // erase the tx from cont
         {
             std::lock_guard<std::shared_mutex> lk1{mtx_cont_wait_tx()};
-            cont_wait_tx().erase(std::make_tuple(tx_id, token));
+            cont_wait_tx().erase(tx_id);
         }
         /**
          * used_ids から tx_id 要素を削除して並行スレッドへコミット処理を許容しては

--- a/src/concurrency_control/bg_work/bg_commit.cpp
+++ b/src/concurrency_control/bg_work/bg_commit.cpp
@@ -94,6 +94,7 @@ void bg_commit::worker() {
             token = std::get<1>(*itr);
             tx_id = std::get<0>(*itr);
             ti = static_cast<session*>(token);
+            if (cont_wait_tx().find(ti->get_waiting_long_tx_id()) != cont_wait_tx().end()) { continue; }
 
             // check conflict between worker
             {

--- a/src/concurrency_control/bg_work/include/bg_commit.h
+++ b/src/concurrency_control/bg_work/include/bg_commit.h
@@ -20,7 +20,7 @@ public:
      * @brief First element of tuple is long tx id to sort container by priority
      * of long transactions.
      */
-    using cont_type = std::set<std::tuple<std::size_t, Token>>;
+    using cont_type = std::map<std::size_t, Token>;
     using worker_cont_type = std::vector<std::thread>;
     using used_ids_type = std::set<std::size_t>;
 

--- a/src/concurrency_control/include/session.h
+++ b/src/concurrency_control/include/session.h
@@ -92,6 +92,7 @@ public:
     void clear_about_long_tx_metadata() {
         set_read_version_max_epoch(0);
         set_long_tx_id(0);
+        set_waiting_long_tx_id(0);
         set_valid_epoch(0);
         set_was_considering_forwarding_at_once(false);
         set_is_forwarding(false);
@@ -329,6 +330,8 @@ public:
     }
 
     [[nodiscard]] std::size_t get_long_tx_id() const { return long_tx_id_; }
+
+    [[nodiscard]] std::size_t get_waiting_long_tx_id() const { return waiting_long_tx_id_; }
 
     overtaken_ltx_set_type& get_overtaken_ltx_set() {
         return overtaken_ltx_set_;
@@ -579,6 +582,8 @@ public:
 
     void set_long_tx_id(std::size_t bid) { long_tx_id_ = bid; }
 
+    void set_waiting_long_tx_id(std::size_t id) { waiting_long_tx_id_ = id; }
+
     void set_read_version_max_epoch(epoch::epoch_t const ep) {
         read_version_max_epoch_.store(ep, std::memory_order_release);
     }
@@ -802,6 +807,11 @@ private:
      * @brief long tx id.
      */
     std::size_t long_tx_id_{};
+
+    /**
+     * @brief waiting ltx id
+     */
+    std::size_t waiting_long_tx_id_{};
 
     /**
      * @brief The ltx set which this transaction overtook.

--- a/src/concurrency_control/ongoing_tx.cpp
+++ b/src/concurrency_control/ongoing_tx.cpp
@@ -203,6 +203,7 @@ bool ongoing_tx::exist_wait_for(session* ti, Status& out_status) {
                         if (do_waiting_bypass_here) {
                             out_status = waiting_bypass(ti);
                         }
+                        ti->set_waiting_long_tx_id(std::get<ongoing_tx::index_id>(elem));
                         return true;
                     }
                 } else {
@@ -212,6 +213,7 @@ bool ongoing_tx::exist_wait_for(session* ti, Status& out_status) {
             }
         }
     }
+    ti->set_waiting_long_tx_id(0);
 
     if (ti->get_was_considering_forwarding_at_once()) {
         // at least, this tx was considering forwarding so needs to check read


### PR DESCRIPTION
bg_commit worker の負荷を減らすために、今試してもあきらかに再度 commit 待ちになりそうなものはスキップするという改良を加えました
案件: https://github.com/project-tsurugi/tsurugi-issues/issues/460

性能評価も上記案件で進行中です。
新設プロパティ名とかは、適宜変えてください。


変更概要
* bg_commit のコンテナタイプを set → map に変更 (5fd621cde4e26b9286d2efbbeb750a3cac8fb71d)
    * もともと set\<ltx_id, token> だったが、 ltx_id はユニークかつ再利用されないためこの変更で問題はない。また、純粋にエントリの検索(挿入位置の検索や削除時の検索を含む)が速くなる
* LTX コミットで待たされた場合には、どの ltx_id のトランザクションに待たされたかを記録するようにした (17b4847a23f013303cb361455a6d46295c89264b session.h)
    * session object に記録用の領域を新設
        * いまのところ、 「ltx_id を記録する」のみとしているが、ほかの情報も記録する価値があるかもしれない
    * long_tx::commit の最初の待ち判定で boundary check で待たされていると判断された場合には、そこに記録
    * 待ちが解消された場合や session 初期化時にはそこをクリア
* bg_commit worker スレッドは、ひとつ コンテナから処理候補を取り出した際に、その ltx が待っている ltx_id が bg_commit コンテナにいるかを確認して飛ばすようにした (17b4847a23f013303cb361455a6d46295c89264b bg_commit.cpp)
    * 待たされている ltx の生存確認に使える安価なものとして bg_commit コンテナを使用した。
    * これだと まだ一度も commit を試していない LTX のスキップができないので、改良の余地はある
* 追加で read area check での待ちの場合にも同様に記録するようにした (05fc5295280e9f51bb763fc6bf294c149ef9b766)
