### PR TITLE
reload memory at lock rechecking in read_record

### DIFF
--- a/src/concurrency_control/interface/helper.cpp
+++ b/src/concurrency_control/interface/helper.cpp
@@ -123,6 +123,7 @@ Status read_record(Record* const rec_ptr, tid_word& tid, std::string& val,
             if (f_check.get_lock_by_gc()) {
                 // gc don't lock for long time, so it waits.
                 _mm_pause();
+                f_check.set_obj(loadAcquire(rec_ptr->get_tidw_ref().get_obj()));
                 continue;
             }
 


### PR DESCRIPTION
read_record が GC とぶつかったときにロックが解放されるまで待つところの処理で、
メモリの再読み込みが抜けていたため無限ループになっている問題の修正です。

案件: project-tsurugi/tsurugi-issues#627