### PR TITLE
Cherrypick unmerged optimizations

### DIFF
--- a/src/concurrency_control/bg_work/bg_commit.cpp
+++ b/src/concurrency_control/bg_work/bg_commit.cpp
@@ -61,8 +61,7 @@ void bg_commit::register_tx(Token token) {
     // lock for container
     {
         std::lock_guard<std::shared_mutex> lk_{mtx_cont_wait_tx()};
-        auto ret = cont_wait_tx().insert(
-                std::make_pair(ti->get_long_tx_id(), token));
+        auto ret = cont_wait_tx().emplace(ti->get_long_tx_id(), token);
         if (!ret.second) {
             // already exist
             LOG_FIRST_N(ERROR, 1)

--- a/src/concurrency_control/bg_work/bg_commit.cpp
+++ b/src/concurrency_control/bg_work/bg_commit.cpp
@@ -62,7 +62,7 @@ void bg_commit::register_tx(Token token) {
     {
         std::lock_guard<std::shared_mutex> lk_{mtx_cont_wait_tx()};
         auto ret = cont_wait_tx().insert(
-                std::make_tuple(ti->get_long_tx_id(), token));
+                std::make_pair(ti->get_long_tx_id(), token));
         if (!ret.second) {
             // already exist
             LOG_FIRST_N(ERROR, 1)
@@ -162,7 +162,7 @@ void bg_commit::worker() {
         // erase the tx from cont
         {
             std::lock_guard<std::shared_mutex> lk1{mtx_cont_wait_tx()};
-            cont_wait_tx().erase(std::make_tuple(tx_id, token));
+            cont_wait_tx().erase(tx_id);
         }
         /**
          * used_ids から tx_id 要素を削除して並行スレッドへコミット処理を許容しては

--- a/src/concurrency_control/bg_work/include/bg_commit.h
+++ b/src/concurrency_control/bg_work/include/bg_commit.h
@@ -20,7 +20,7 @@ public:
      * @brief First element of tuple is long tx id to sort container by priority
      * of long transactions.
      */
-    using cont_type = std::set<std::tuple<std::size_t, Token>>;
+    using cont_type = std::map<std::size_t, Token>;
     using worker_cont_type = std::vector<std::thread>;
     using used_ids_type = std::set<std::size_t>;
 

--- a/src/concurrency_control/include/local_set.h
+++ b/src/concurrency_control/include/local_set.h
@@ -64,6 +64,8 @@ private:
     tid_word tid_{};
 };
 
+static_assert(std::is_nothrow_move_constructible_v<read_set_obj>);
+
 class write_set_obj { // NOLINT
 public:
     // for update / upsert / insert

--- a/src/concurrency_control/include/session.h
+++ b/src/concurrency_control/include/session.h
@@ -426,9 +426,9 @@ public:
         auto itr = get_ltx_storage_read_set().find(st);
         if (itr == get_ltx_storage_read_set().end()) {
             // no hit
-            get_ltx_storage_read_set().insert(std::make_pair(
+            get_ltx_storage_read_set().emplace(
                     st, std::make_tuple("", scan_endpoint::EXCLUSIVE, "",
-                                        scan_endpoint::EXCLUSIVE)));
+                                        scan_endpoint::EXCLUSIVE));
         }
     }
 
@@ -439,9 +439,9 @@ public:
         auto itr = get_ltx_storage_read_set().find(st);
         if (itr == get_ltx_storage_read_set().end()) {
             // no hit
-            get_ltx_storage_read_set().insert(std::make_pair(
+            get_ltx_storage_read_set().emplace(
                     st, std::make_tuple(key, scan_endpoint::INCLUSIVE, key,
-                                        scan_endpoint::INCLUSIVE)));
+                                        scan_endpoint::INCLUSIVE));
         } else {
             std::string& now_lkey = std::get<0>(itr->second);
             scan_endpoint& now_lpoint = std::get<1>(itr->second);

--- a/src/concurrency_control/include/tid.h
+++ b/src/concurrency_control/include/tid.h
@@ -134,6 +134,8 @@ public:
 private:
 };
 
+static_assert(std::is_nothrow_move_constructible_v<tid_word>);
+
 inline std::ostream& operator<<(std::ostream& out, tid_word tid) { // NOLINT
     out << "lock_:" << tid.get_lock() << ", lock_by_gc:" << tid.get_lock_by_gc()
         << ", latest_:" << tid.get_latest() << ", absent_:" << tid.get_absent()

--- a/src/concurrency_control/include/tid.h
+++ b/src/concurrency_control/include/tid.h
@@ -33,7 +33,7 @@ public:
     } // NOLINT : clang-tidy order to initialize other member, but
     // it occurs compile error.
     tid_word(const uint64_t obj) { obj_ = obj; } // NOLINT : the same as above.
-    tid_word(const tid_word& right)              // NOLINT
+    tid_word(const tid_word& right) noexcept     // NOLINT
         : obj_(right.get_obj()) {}               // NOLINT : the same as above.
 
     tid_word& operator=(const tid_word& right) { // NOLINT

--- a/src/concurrency_control/include/wp_meta.h
+++ b/src/concurrency_control/include/wp_meta.h
@@ -130,20 +130,20 @@ public:
     }
 
     static epoch::epoch_t
-    wp_result_elem_extract_epoch(wp_result_elem_type elem) {
+    wp_result_elem_extract_epoch(const wp_result_elem_type& elem) {
         return std::get<0>(elem);
     }
 
-    static std::size_t wp_result_elem_extract_id(wp_result_elem_type elem) {
+    static std::size_t wp_result_elem_extract_id(const wp_result_elem_type& elem) {
         return std::get<1>(elem);
     }
 
-    static bool wp_result_elem_extract_was_committed(wp_result_elem_type elem) {
+    static bool wp_result_elem_extract_was_committed(const wp_result_elem_type& elem) {
         return std::get<2>(elem);
     }
 
-    static std::tuple<bool, std::string, std::string>
-    wp_result_elem_extract_write_result(wp_result_elem_type elem) {
+    static const std::tuple<bool, std::string, std::string>&
+    wp_result_elem_extract_write_result(const wp_result_elem_type& elem) {
         return std::get<3>(elem);
     }
 

--- a/src/concurrency_control/local_set.cpp
+++ b/src/concurrency_control/local_set.cpp
@@ -57,8 +57,7 @@ void local_write_set::push(Token token, write_set_obj&& elem) {
             elem.get_key(key);
             if (itr == smap.end()) {
                 // not found
-                smap.insert(std::make_pair(elem.get_storage(),
-                                           std::make_tuple(key, key)));
+                smap.emplace(elem.get_storage(), std::make_tuple(key, key));
             } else {
                 // found, check left key
                 if (key < std::get<0>(itr->second)) {
@@ -181,8 +180,7 @@ Status local_sequence_set::push(SequenceId const id,
         } // new value is smaller than old ones
         return Status::WARN_ALREADY_EXISTS;
     } // not found
-    auto ret =
-            set().insert(std::make_pair(id, std::make_tuple(version, value)));
+    auto ret = set().emplace(id, std::make_tuple(version, value));
     if (!ret.second) {
         LOG_FIRST_N(ERROR, 1) << log_location_prefix
                               << "unreachable path. maybe mixed some access.";

--- a/src/concurrency_control/ongoing_tx.cpp
+++ b/src/concurrency_control/ongoing_tx.cpp
@@ -48,7 +48,7 @@ Status ongoing_tx::waiting_bypass(session* ti) {
                 continue;
             }
 
-            bypass_target.insert(std::make_tuple(the_tx_id, token));
+            bypass_target.emplace(the_tx_id, token);
             // set valid epoch if need
             if (ti->get_valid_epoch() > token->get_valid_epoch()) {
                 // update valid epoch and check rub violation

--- a/src/concurrency_control/sequence.cpp
+++ b/src/concurrency_control/sequence.cpp
@@ -146,11 +146,11 @@ Status sequence::sequence_map_push(SequenceId const id,
                                    SequenceValue const value) {
     // push
     sequence::value_type new_val{};
-    auto ret = sequence::sequence_map().insert(std::make_pair(id, new_val));
+    auto ret = sequence::sequence_map().emplace(id, new_val);
     if (ret.second) {
         // insert success
-        auto ret2 = ret.first->second.insert(
-                std::make_pair(epoch, std::make_tuple(version, value)));
+        auto ret2 = ret.first->second.emplace(
+                epoch, std::make_tuple(version, value));
         if (!ret2.second) {
             // This object must be operated by here.
             LOG_FIRST_N(ERROR, 1)
@@ -240,7 +240,7 @@ Status sequence::sequence_map_update(SequenceId const id,
     std::get<1>(new_tuple) = value;
     if (found_ob_itr == found_id_itr->second.end()) {
         // not found
-        found_id_itr->second.insert(std::make_pair(epoch, new_tuple));
+        found_id_itr->second.emplace(epoch, new_tuple);
     } else {
         // found
         found_ob_itr->second = new_tuple;

--- a/src/concurrency_control/wp_meta.cpp
+++ b/src/concurrency_control/wp_meta.cpp
@@ -167,8 +167,8 @@ void wp_meta::push_write_range(std::size_t txid, std::string_view left_key,
                                std::string_view right_key) {
     std::lock_guard<std::shared_mutex> lk{get_mtx_write_range()};
 
-    auto ret_pair = get_write_range().insert(
-            std::make_pair(txid, std::make_tuple(left_key, right_key)));
+    auto ret_pair = get_write_range().emplace(
+            txid, std::make_tuple(left_key, right_key));
     if (!ret_pair.second) {
         // already exist, not inserted
         LOG_FIRST_N(ERROR, 1) << log_location_prefix


### PR DESCRIPTION
いままでブランチには入れていたが、master にマージされていないコミット群のうち、
ほぼ自明に適用可能な最適化を cherry-pick で持ってきたものです。

* 1d884ba52cb176deba19217c1ea96ad7ca7c433a: tid_word の copy ctor を noexcept にする
    * → move ctor がないときには copy ctor が呼ばれるので move ctor が noexcept になる
    * → これを含む read_set_obj が nothrow_move_constructible になる
    * → `std::vector<read_set_obj>` に対する各種操作が効率化
* d38d9ee1fdb6979c151595c624f57e643b5e9a6d: bg_commit のコンテナタイプを set → map に変更
    * #140 のうちの自明な部分のみを取り出したもの
    * もともと `set<ltx_id, token>` だったが、 ltx_id はユニークかつ再利用されないためこの変更で問題はない。また、純粋にエントリの検索(挿入位置の検索や削除時の検索を含む)が速くなる
* 7029e0b0ff6923f89adda28d48b69dc3e84deb92: wp_result_elem_type から値を取り出す関数を参照で済ませる
    * wp_meta_ptr->wp_result_set に対して loop し、この tuple から要素を取り出す関数を呼ぶ際に tuple がコピーされて遅くなっている問題を解消する
    * この tuple は std::string を含むのでコピーは重く、またこのループはかなり回るため、積算的に遅くなっていた