### PR TITLE
set durable epoch correctly after recovery

### DIFF
--- a/src/concurrency_control/interface/start_up.cpp
+++ b/src/concurrency_control/interface/start_up.cpp
@@ -162,6 +162,7 @@ Status init_body(database_options options) { // NOLINT
 
         // epoch adjustment
 #if defined(PWAL)
+        epoch::set_datastore_durable_epoch(datastore::get_datastore()->last_epoch());
         auto new_epoch = epoch::initial_epoch;
         if (datastore::get_datastore()->last_epoch() >= epoch::initial_epoch) {
             new_epoch = datastore::get_datastore()->last_epoch() + 1;


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/796 を解決する修正です。

修正前は再起動後のrecovery後に shirakami::epoch::datastore_durable_epochの値が設定されず、以前の値が残ってしまっていました。

https://github.com/project-tsurugi/shirakami/blob/2550e4b2e96772dc8c660c6efff95826a833772e/src/concurrency_control/include/epoch.h#L42

このため、複数のテストケースを一回の起動で実行するようなケースにおいて、2番目のテストケースで下記関数でdurable callbackが登録された際、古い値でコールバックを呼んでしまっていました。
https://github.com/project-tsurugi/shirakami/blob/2550e4b2e96772dc8c660c6efff95826a833772e/src/database/tx_state_notification.cpp#L14

本修正によってrecovery直後にlimestoneから最大のdurable epochを取得して設定され、durable callbackの登録時に正しいdurable epochが戻されるようになります。


