### PR TITLE
fix race condition problem at start of OCC operation

### DIFF
--- a/src/concurrency_control/include/session.h
+++ b/src/concurrency_control/include/session.h
@@ -376,8 +376,9 @@ public:
     // ========== end: getter
 
     void process_before_start_step() {
-        get_operating()++;
+        // make sure that step_epoch is set when operating becomes 0 to 1
         set_step_epoch(epoch::get_global_epoch());
+        get_operating()++;
     }
 
     void process_before_finish_step() {

--- a/src/concurrency_control/include/session.h
+++ b/src/concurrency_control/include/session.h
@@ -139,12 +139,13 @@ public:
 
     /**
      * @brief long tx find high priority short.
+     * @param for_check true if only status check (with lower log level).
      * @pre This is called by long tx.
      * @return Status::OK success
      * @return Status::WARN_PREMATURE There is a high priority short tx.
      * @return Status::ERR_FATAL programming error.
      */
-    [[nodiscard]] Status find_high_priority_short() const;
+    [[nodiscard]] Status find_high_priority_short(bool for_check) const;
 
     /**
      * @brief Find wp about @a st from wp set.

--- a/src/concurrency_control/interface/long_tx/search.cpp
+++ b/src/concurrency_control/interface/long_tx/search.cpp
@@ -105,7 +105,7 @@ static Status check_before_execution(session* const ti, Storage const storage) {
         return Status::WARN_PREMATURE;
     }
     // wait for high priority some tx
-    if (ti->find_high_priority_short() == Status::WARN_PREMATURE) {
+    if (ti->find_high_priority_short(false) == Status::WARN_PREMATURE) {
         return Status::WARN_PREMATURE;
     }
     // check for read area invalidation

--- a/src/concurrency_control/interface/read_only_tx/search.cpp
+++ b/src/concurrency_control/interface/read_only_tx/search.cpp
@@ -12,7 +12,7 @@ Status search_key(session* const ti, Storage const storage,
     if (epoch::get_global_epoch() < ti->get_valid_epoch()) {
         return Status::WARN_PREMATURE;
     }
-    if (ti->find_high_priority_short() == Status::WARN_PREMATURE) {
+    if (ti->find_high_priority_short(false) == Status::WARN_PREMATURE) {
         return Status::WARN_PREMATURE;
     }
 

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -191,7 +191,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
             return Status::WARN_PREMATURE;
         }
         // check high priori tx
-        if (ti->find_high_priority_short() == Status::WARN_PREMATURE) {
+        if (ti->find_high_priority_short(false) == Status::WARN_PREMATURE) {
             return Status::WARN_PREMATURE;
         }
         // check for read area invalidation

--- a/src/concurrency_control/session.cpp
+++ b/src/concurrency_control/session.cpp
@@ -125,7 +125,7 @@ std::set<std::size_t> session::extract_wait_for() {
     return wait_for;
 }
 
-Status session::find_high_priority_short() const {
+Status session::find_high_priority_short(bool for_check) const {
     if (get_tx_type() == transaction_options::transaction_type::SHORT) {
         LOG_FIRST_N(ERROR, 1) << log_location_prefix << "unreachable path";
         return Status::ERR_FATAL;
@@ -148,15 +148,18 @@ Status session::find_high_priority_short() const {
                 // transaction order
                 itr.get_step_epoch() < get_valid_epoch()) {
             // logging
-            std::string str_ltx_id{};
-            std::string str_stx_id{};
-            get_tx_id(static_cast<Token>(const_cast<session*>(this)),
-                      str_ltx_id);
-            get_tx_id(static_cast<Token>(const_cast<session*>(&itr)),
-                      str_stx_id);
-            VLOG(log_info) << log_location_prefix
-                           << "ltx warn premature by short tx, ltx id: "
-                           << str_ltx_id << ", stx id: " << str_stx_id;
+            if (VLOG_IS_ON(for_check ? log_debug : log_error)) {
+                std::string str_ltx_id{};
+                std::string str_stx_id{};
+                get_tx_id(static_cast<Token>(const_cast<session*>(this)),
+                          str_ltx_id);
+                get_tx_id(static_cast<Token>(const_cast<session*>(&itr)),
+                          str_stx_id);
+                LOG(INFO) << log_location_prefix
+                          << "ltx warn premature by short tx, ltx id: "
+                          << str_ltx_id << ", stx id: " << str_stx_id;
+
+            }
             return Status::WARN_PREMATURE;
         }
     }

--- a/src/concurrency_control/transaction_state.cpp
+++ b/src/concurrency_control/transaction_state.cpp
@@ -44,7 +44,7 @@ Status acquire_tx_state_handle_body(Token const token, // NOLINT
                 // wait staging
                 ti->get_valid_epoch() > epoch::get_global_epoch() ||
                 // wait high priori short
-                ti->find_high_priority_short() == Status::WARN_PREMATURE) {
+                ti->find_high_priority_short(true) == Status::WARN_PREMATURE) {
             ts.set_kind(TxState::StateKind::WAITING_START);
         } else {
             ts.set_kind(TxState::StateKind::STARTED);
@@ -118,7 +118,7 @@ Status check_tx_state_body(TxStateHandle handle, TxState& out) {
         if (ts.state_kind() == TxState::StateKind::WAITING_START) {
             // check high priori stx
             auto* ti = static_cast<session*>(ts.get_token());
-            if (ti->find_high_priority_short() != Status::WARN_PREMATURE) {
+            if (ti->find_high_priority_short(true) != Status::WARN_PREMATURE) {
                 ts.set_kind(TxState::StateKind::STARTED);  // for internal
                 out.set_kind(TxState::StateKind::STARTED); // for external
             }                                              // else : premature


### PR DESCRIPTION
OCC 操作開始時の状態変更に穴があり、並列して RTX を開始する際の状態チェックでエラー (WARN_PREMATURE) になる可能性のあるパスがありました。それをつぶす修正です。

加えて、判定ロジック中のエラー出力レベルを変更して、
アサーションチェック的なチェック時には、より高いログレベルで、
単なる状態確認的なチェックの場合には、より低いログレベルとします。

案件: project-tsurugi/tsurugi-issues#758