### PR TITLE
expand Record tid_word to 128-bit

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(shirakami
         PRIVATE ${tbb_prefix}tbbmalloc_proxy
         PRIVATE Threads::Threads
         PRIVATE yakushima
+        PUBLIC atomic
         )
 
 if (BUILD_PWAL)

--- a/src/concurrency_control/include/tid.h
+++ b/src/concurrency_control/include/tid.h
@@ -24,9 +24,11 @@ public:
             bool lock_by_gc_ : 1;
             bool latest_ : 1;
             bool absent_ : 1;
-            std::uint64_t tid_ : 60;
+            int : 8; // reserved
+            std::uint64_t tid_ : 52;
             bool by_short_ : 1;
-            epoch::epoch_t epoch_ : 63;
+            int : 11; // reserved
+            epoch::epoch_t epoch_ : 52;
         };
     };
 

--- a/src/concurrency_control/include/tid.h
+++ b/src/concurrency_control/include/tid.h
@@ -18,15 +18,15 @@ namespace shirakami {
 class tid_word { // NOLINT
 public:
     union { // NOLINT
-        uint64_t obj_;
+        __uint128_t obj_;
         struct {
             bool lock_ : 1;
             bool lock_by_gc_ : 1;
             bool latest_ : 1;
             bool absent_ : 1;
-            std::uint64_t tid_ : 28; // NOLINT
+            std::uint64_t tid_ : 60;
             bool by_short_ : 1;
-            epoch::epoch_t epoch_ : 31; // NOLINT
+            epoch::epoch_t epoch_ : 63;
         };
     };
 
@@ -34,7 +34,7 @@ public:
         : obj_(0) {
     } // NOLINT : clang-tidy order to initialize other member, but
     // it occurs compile error.
-    tid_word(const uint64_t obj) { obj_ = obj; } // NOLINT : the same as above.
+    tid_word(const __uint128_t obj) { obj_ = obj; } // NOLINT : the same as above.
     tid_word(const tid_word& right) noexcept     // NOLINT
         : obj_(right.get_obj()) {}               // NOLINT : the same as above.
 
@@ -61,9 +61,9 @@ public:
 
     bool empty() { return obj_ == 0; } // NOLINT
 
-    uint64_t& get_obj() { return obj_; } // NOLINT
+    __uint128_t& get_obj() { return obj_; } // NOLINT
 
-    const uint64_t& get_obj() const { return obj_; } // NOLINT
+    const __uint128_t& get_obj() const { return obj_; } // NOLINT
 
     bool get_lock() { return lock_; } // NOLINT
 
@@ -113,7 +113,7 @@ public:
 
     void set_by_short(const bool tf) { by_short_ = tf; } // NOLINT
 
-    void set_obj(const uint64_t obj) { this->obj_ = obj; } // NOLINT
+    void set_obj(const __uint128_t obj) { this->obj_ = obj; } // NOLINT
 
     [[maybe_unused]] void set_tid(const uint64_t tid) {
         this->tid_ = tid; // NOLINT
@@ -136,6 +136,7 @@ public:
 private:
 };
 
+static_assert(sizeof(tid_word) == sizeof(tid_word{}.obj_)); // NOLINT(*-union-access)
 static_assert(std::is_nothrow_move_constructible_v<tid_word>);
 
 inline std::ostream& operator<<(std::ostream& out, tid_word tid) { // NOLINT


### PR DESCRIPTION
Record tid_word (64bit) 中に埋められている epoch, tid フィールドのビット長がそれぞれ 31bit, 28bit と短いため、tsurugidb として使用しているうちに一周回ってしまう危険性があります。
(例えば、現在デフォルト設定では epoch は 3ms で1増加するのでepoch フィールドは 75日弱で一周する)
この対策として Record tid_word を 128bit に拡張し、増えた64bit から epoch, tid のフィールドに回して対応します。
* GCC11/13 の g++, libatomic では x86_64 arch に対して128bit 整数型および、 128bit整数の atomic memory load, store, cas が cmpxchg16b または AVX 命令経由で可能です
    * shirakami YCSB ベンチマークでは大きな性能劣化は見られませんでした
* (2^52 / 1000000 / 86400 / 365.25 > 142 であるため)  52bit あれば 秒間100万増加しても 140年以上持つ計算なので、各フィールドを 52bit まで広げます (残り19bit は予約領域)
