### PR TITLE
add an option to set the initial random seed to ycsb benchmark program

### DIFF
--- a/bench/include/random.h
+++ b/bench/include/random.h
@@ -26,6 +26,11 @@ public:
         s.at(1) = splitMix64(s.at(0));
     }
 
+    void seed(std::uint64_t seed) {
+        s.at(0) = seed;
+        s.at(1) = splitMix64(seed);
+    }
+
     static uint64_t splitMix64(std::uint64_t seed) {    // NOLINT
         std::uint64_t z = (seed += 0x9e3779b97f4a7c15); // NOLINT
         z = (z ^ (z >> 30U)) * 0xbf58476d1ce4e5b9;      // NOLINT

--- a/bench/ycsb/readme.md
+++ b/bench/ycsb/readme.md
@@ -64,6 +64,9 @@ cd [/path/to/release_build]/bench/ycsb
 - `-val_length`
   - byte size of val.
   - default : `4`
+- `-random_seed`
+  - seed for the internal prng
+  - default : (using random value from another random number generator)
 
 ### Example
 - YCSB-A

--- a/bench/ycsb/ycsb.cpp
+++ b/bench/ycsb/ycsb.cpp
@@ -63,6 +63,7 @@ DEFINE_double(skew, 0.0, "access skew of transaction.");               // NOLINT
 DEFINE_uint64(thread, 1, "# worker threads.");                         // NOLINT
 DEFINE_string(transaction_type, "short", "type of transaction.");      // NOLINT
 DEFINE_uint64(val_length, 4, "# length of value(payload).");           // NOLINT
+DEFINE_uint64(random_seed, 0, "random seed.");
 
 static bool isReady(const std::vector<char>& readys); // NOLINT
 static void waitForReady(const std::vector<char>& readys);
@@ -197,6 +198,12 @@ static void load_flags() {
                    << "Length of val must be larger than 0.";
     }
 
+    if (!gflags::GetCommandLineFlagInfoOrDie("random_seed").is_default) {
+        printf("FLAGS_random_seed : %zu\n", FLAGS_random_seed); // NOLINT
+    } else {
+        printf("FLAGS_random_seed : (unset)\n"); // NOLINT
+    }
+
     printf("Fin load_flags()\n"); // NOLINT
 }
 
@@ -234,6 +241,9 @@ void worker(const std::size_t thid, char& ready, const bool& start,
     // init work
 
     Xoroshiro128Plus rnd;
+    if (!gflags::GetCommandLineFlagInfoOrDie("random_seed").is_default) {
+        rnd.seed(FLAGS_random_seed + thid);
+    }
     FastZipf zipf(&rnd, FLAGS_skew, FLAGS_record);
     std::reference_wrapper<Result> myres = std::ref(res[thid]);
 


### PR DESCRIPTION
shirakami の ycsb ベンチマークプログラムのスコアのばらつきが多いため、これを少しでも減らせるように、プログラムが使用している疑似乱数のシードを外部から指定することができる起動時オプションを追加する変更です。