### PR TITLE
OCC read verify fail if tombstone Record is replaced by newly allocated Record

### DIFF
--- a/src/concurrency_control/interface/short_tx/termination.cpp
+++ b/src/concurrency_control/interface/short_tx/termination.cpp
@@ -197,6 +197,14 @@ Status read_verify(session* ti, tid_word read_tid, tid_word check,
         auto rc = get<Record>(storage, rec_ptr->get_key_view(), rec_ptr2);
         if (rc == Status::OK && rec_ptr2 != rec_ptr) {
             // another record is inserted at the same location (key) on yakushima
+
+            // allow if rec_ptr2 is inserting record
+            tid_word check2{};
+            std::string unused{};
+            auto rr = read_record(rec_ptr2, check2, unused, false);
+            if (rr == Status::WARN_CONCURRENT_INSERT) { return Status::OK; }
+
+            // the record is modified
             return Status::ERR_CC;
         }
     }

--- a/test/tsurugi_issues/tsurugi_issue714_2_test.cpp
+++ b/test/tsurugi_issues/tsurugi_issue714_2_test.cpp
@@ -1,0 +1,103 @@
+
+#include "test_tool.h"
+
+#include "concurrency_control/include/epoch.h"
+#include "concurrency_control/include/garbage.h"
+#include "concurrency_control/include/session.h"
+
+#include "shirakami/interface.h"
+#include "index/yakushima/include/interface.h"
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+using namespace shirakami;
+
+// tsurugi issue #714 (2):
+// tombstone record is unhooked by Record-GC even if it is in local read-set.
+// read-verify compares the saved tid with the tid of Record that is unhooked and stored in garbage::container_rec,
+// so not be aware of the newly created Record for the same key.
+// to fix: (a) guard Records in local read-set from Record-GC,
+// or      (b) adjust read-verify to work even if Record is unhooked.
+
+namespace shirakami::testing {
+
+class tsurugi_issue714_2_test : public ::testing::Test {
+public:
+    static void call_once_f() {
+        google::InitGoogleLogging("shirakami-test-concurrency_control-complicated-tsurugi_issue714_2_test");
+        // FLAGS_stderrthreshold = 0;
+    }
+
+    void SetUp() override {
+        std::call_once(init_, call_once_f);
+        init(); // NOLINT
+    }
+
+    void TearDown() override { fin(); }
+
+private:
+    static inline std::once_flag init_;
+};
+
+TEST_F(tsurugi_issue714_2_test, must_detect_the_change_of_tombstone) {
+    // Setup: make tombstone at "A"
+
+    // expect
+    // OCC1: read "A"     -> NOT_FOUND
+    // RecGC: run
+    // OCC2: insert "A" 2 -> OK
+    // OCC2: commit       -> OK
+    // OCC1: commit       -> ERR_CC
+
+    // before fix ti#714(2):
+    // OCC1: read "A"     -> NOT_FOUND
+    // RecGC: run
+    // OCC2: insert "A" 2 -> OK
+    // OCC2: commit       -> OK
+    // OCC1: commit       -> OK  <- bug
+
+    Storage st{};
+    ASSERT_OK(create_storage("", st));
+    Token s1{};
+    Token s2{};
+    ASSERT_OK(enter(s1));
+    ASSERT_OK(enter(s2));
+
+    // stop gc
+    std::unique_lock<std::mutex> lk{garbage::get_mtx_cleaner()};
+
+    // setup
+    ASSERT_OK(tx_begin({s1, transaction_options::transaction_type::SHORT}));
+    ASSERT_OK(insert(s1, st, "0", "0"));
+    ASSERT_OK(insert(s1, st, "a", "0"));
+    ASSERT_OK(commit(s1));
+    ASSERT_OK(tx_begin({s1, transaction_options::transaction_type::SHORT}));
+    ASSERT_OK(delete_record(s1, st, "a"));
+    ASSERT_OK(commit(s1));
+    wait_epoch_update();  // wait next epoch after delete
+    // setup done
+
+    std::string str;
+    ASSERT_OK(tx_begin({s1, transaction_options::transaction_type::SHORT}));
+    ASSERT_EQ(search_key(s1, st, "a", str), Status::WARN_NOT_FOUND);
+
+    // start gc
+    lk.unlock();
+
+    // wait gc
+    wait_epoch_update();
+    wait_epoch_update();
+    wait_epoch_update();
+
+    ASSERT_OK(tx_begin({s2, transaction_options::transaction_type::SHORT}));
+    ASSERT_OK(insert(s2, st, "a", "2"));
+    ASSERT_OK(commit(s2));
+
+    EXPECT_EQ(commit(s1), Status::ERR_CC);
+
+    ASSERT_OK(leave(s1));
+    ASSERT_OK(leave(s2));
+}
+
+} // namespace shirakami::testing


### PR DESCRIPTION
OCC で Record を読むと commit 時の read verify で Record の変更をチェックしますが、
読んだものが tombstone Record の場合には commit 前に Record GC によって回収されてしまうことがあります。
Record GC により回収され、その同じ key 位置に別のトランザクションによって Record が新規作成されてしまっても、read verify は回収されてしまった Record を見に行き、変更されていないとみなすため、変更を検出できないという問題がありました。

案件: project-tsurugi/tsurugi-issues#714

この問題への対応として、
(a) local read set にある Record は Record GC から回収するようにする
または
(b) OCC read verify を調整して Record GC に回収されてしまっていても多対応できるようにする
の二つの対応方法が考えられますが、(a) の改修は大規模になりそうなため (b) の方針での対応としました。

OCC read verify の通常チェックの後に、 もし対象 Record が absent Record であった場合には yakushima index の 同じ key 位置を検査し、 別の Record が置かれていた場合、
(その Record が inserting Record (placeholder) でない限りは) ERR_CC とするという
チェックを追加しました。