### PR TITLE
build: make RPATH relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ option(BUILD_ROCKSDB_BENCH "Build rocksdb benchmark." OFF)
 
 option(FORMAT_FILES_WITH_CLANG_FORMAT_BEFORE_EACH_BUILD "If the command clang-format is available, format source files before each build. Turn this off if the build time is too slow." OFF)
 
+if (FORCE_INSTALL_RPATH)
+    message(DEPRECATION "FORCE_INSTALL_RPATH is obsoleted")
+endif (FORCE_INSTALL_RPATH)
+
 if (BUILD_PWAL)
   find_package(limestone REQUIRED)
 endif()

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 * CMake `>= 3.10`
 * C++ Compiler `>= C++17`
-* Build related libraries - on Ubuntu, you can install with following command. 
+* Build related libraries - on Ubuntu, you can install with following command.
 Please check in advance whether ubuntu.deps is correct.:
 
 ```sh
@@ -44,8 +44,6 @@ Available options:
    * Create static libraries instead of shared libraries
 * `-DCMAKE_PREFIX_PATH=<installation directory>`
    * Indicate prerequiste installation directory (ex. yakushima)
-* `-DFORCE_INSTALL_RPATH=ON`
-   * Force set RPATH for non-default library paths
 * `-DFORMAT_FILES_WITH_CLANG_FORMAT_BEFORE_EACH_BUILD=ON`
    * Use formatting for source files
 * `-DTSURUGI_FAST_SHUTDOWN=ON`
@@ -105,7 +103,7 @@ Available options:
       succeeds in an environment with low contention. Because, as a result,
       the probability of aborting is small.
 
-## Install 
+## Install
 
 ```sh
 ninja install

--- a/cmake/InstallOptions.cmake
+++ b/cmake/InstallOptions.cmake
@@ -28,37 +28,6 @@ function(install_custom target_name export_name)
             DESTINATION ${CMAKE_INSTALL_BINDIR}
             COMPONENT Runtime
     )
-    # Add INSTALL_RPATH from CMAKE_INSTALL_PREFIX and CMAKE_PREFIX_PATH
-    # The default behavior of CMake omits RUNPATH if it is already in CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES.
-    if (FORCE_INSTALL_RPATH)
-        get_target_property(target_type ${target_name} TYPE)
-        if (target_type STREQUAL "SHARED_LIBRARY"
-                OR target_type STREQUAL "EXECUTABLE")
-            get_target_property(rpath ${target_name} INSTALL_RPATH)
-
-            # add ${CMAKE_INSTALL_PREFIX}/lib if it is not in system link directories
-            get_filename_component(p "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-            list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${p}" is_system)
-            if (is_system STREQUAL "-1")
-                list(APPEND rpath "${p}")
-            endif()
-
-            # add each ${CMAKE_PREFIX_PATH}/lib
-            foreach (p IN LISTS CMAKE_PREFIX_PATH)
-                get_filename_component(p "${p}/${CMAKE_INSTALL_LIBDIR}" ABSOLUTE)
-                list(APPEND rpath "${p}")
-            endforeach()
-
-            if (rpath)
-                set_target_properties(${target_name} PROPERTIES
-                    INSTALL_RPATH "${rpath}")
-            endif()
-
-            # add other than */lib paths
-            set_target_properties(${target_name} PROPERTIES
-                INSTALL_RPATH_USE_LINK_PATH ON)
-        endif()
-    endif (FORCE_INSTALL_RPATH)
     # Install include files of interface libraries manually
     # INTERFACE_INCLUDE_DIRECTORIES must contains the following entries:
     # - one or more `$<BUILD_INTERFACE:...>` paths (may be absolute paths on source-tree)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,8 @@ endif()
 
 set_target_properties(shirakami
         PROPERTIES
-        LIBRARY_OUTPUT_NAME "kvs"
+                INSTALL_RPATH "\$ORIGIN/../lib"
+                LIBRARY_OUTPUT_NAME "kvs"
         )
 
 set_compile_options(shirakami)


### PR DESCRIPTION
This Pull Request modifies CMake Property `INSTALL_RPATH` to relative path based `$ORIGIN`, and changes to disable unnecessary CMake Property `FORCE_INSTALL_RPATH`.