### PR TITLE
prevent lpwal flush daemon from flushing buffer a second time in one epoch

### DIFF
--- a/src/datastore/limestone/lpwal.cpp
+++ b/src/datastore/limestone/lpwal.cpp
@@ -85,8 +85,15 @@ void daemon_work() {
 
         // do work
         for (auto&& es : session_table::get_session_table()) {
+            // FIXME: use durable epoch instead of min_log_epoch (this is write version)
+            // copied from short_tx::commit
             // flush work
-            flush_log(&es);
+            auto oldest_log_epoch{es.get_lpwal_handle().get_min_log_epoch()};
+            if (oldest_log_epoch != 0 && // mean the wal buffer is not empty.
+                oldest_log_epoch != epoch::get_global_epoch()) {
+                // should flush
+                flush_log(&es);
+            }
         }
     }
 }


### PR DESCRIPTION
shirakami は トランザクションログを書く際に 1 epoch 分バッファリングするようにしている。(そうしないモードも最近追加したが)

だが、バックグラウンド lpwal worker は、バッファリングをせずに、バッファにたまっているのを見つけ次第、掃きだしている。
これを OCC の時のバッファリング判定と同様の条件でバッファリングするように変更する。
掃きだしは fsync を伴うので時間がかかるが、バックグラウンドからの掃きだしは、トランザクションの precommit 動作をブロックするので、不要な掃きだしを減らすと、このブロックによる待ちを減らすことができる。

関連案件: project-tsurugi/tsurugi-issues#1020

OCC の時のバッファリング判定は durble epoch でなく major write version を見ているので正確ではないため、それは別途変更することにする。
