### PR TITLE
implement reverse scan with limited functionality

### DIFF
--- a/include/shirakami/interface.h
+++ b/include/shirakami/interface.h
@@ -234,6 +234,13 @@ Status leave(Token token); // NOLINT
  * this argument. This argument limits the number of results.
  * @attention This scan limits range which is specified by @b l_key, @b l_end,
  * @b r_key, and @b r_end.
+ * @warning current implementation of `max_size` discards placeholder/tombstone records after fetching `max_size`
+ * records from yakushima, so it's possible that the actual number of records fetched is less than `max_size` even
+ * though there are plenty of records.
+ * @param[in] right_to_left if true, the scan starts from right end to left. Otherwise, left end to rigth.
+ * When this is set to true, current implementation has following limitation: 1. `max_size` must be set to 1
+ * so that at most one entry is hit and returned as scan result 2. r_end must be scan_endpoint::INF so that the scan
+ * is performed from unbounded right end. Status::ERR_FATAL is returned if these conditions are not met.
  * @return Status::OK success.
  * @return Status::WARN_INVALID_KEY_LENGTH The @a key is invalid. Key length
  * should be equal or less than 30KB.
@@ -251,7 +258,8 @@ Status leave(Token token); // NOLINT
 Status open_scan(Token token, Storage storage, std::string_view l_key,
                  scan_endpoint l_end, std::string_view r_key,
                  scan_endpoint r_end, ScanHandle& handle,
-                 std::size_t max_size = 0); // NOLINT
+                 std::size_t max_size = 0,
+                 bool right_to_left = false); // NOLINT
 
 /**
  * @brief advance cursor

--- a/include/shirakami/interface.h
+++ b/include/shirakami/interface.h
@@ -258,7 +258,7 @@ Status leave(Token token); // NOLINT
 Status open_scan(Token token, Storage storage, std::string_view l_key,
                  scan_endpoint l_end, std::string_view r_key,
                  scan_endpoint r_end, ScanHandle& handle,
-                 std::size_t max_size = 0,
+                 std::size_t max_size = 0,    // NOLINT
                  bool right_to_left = false); // NOLINT
 
 /**

--- a/src/datastore/limestone/datastore.cpp
+++ b/src/datastore/limestone/datastore.cpp
@@ -208,7 +208,7 @@ void scan_all_and_logging() {
                               yakushima::node_version64*>>
                 nvec;
         auto rc = scan(each_st, "", scan_endpoint::INF, "", scan_endpoint::INF,
-                       0, scan_res, &nvec);
+                       0, scan_res, &nvec, false);
         if (rc == Status::OK) {
             // It found some records
             for (auto&& each_rec : scan_res) {

--- a/src/index/yakushima/include/interface.h
+++ b/src/index/yakushima/include/interface.h
@@ -97,11 +97,12 @@ scan(Storage st, std::string_view const l_key, scan_endpoint const l_end,
      std::size_t const max_size,
      std::vector<std::tuple<std::string, Record**, std::size_t>>& scan_res,
      std::vector<std::pair<yakushima::node_version64_body,
-                           yakushima::node_version64*>>* nvec) {
+                           yakushima::node_version64*>>* nvec,
+                           bool right_to_left) {
     auto rc{yakushima::scan(
             {reinterpret_cast<char*>(&st), sizeof(st)}, // NOLINT
             l_key, parse_scan_endpoint(l_end), r_key,
-            parse_scan_endpoint(r_end), scan_res, nvec, max_size)};
+            parse_scan_endpoint(r_end), scan_res, nvec, max_size, right_to_left)};
     if (rc == yakushima::status::WARN_STORAGE_NOT_EXIST) {
         return Status::WARN_STORAGE_NOT_FOUND;
     }

--- a/test/concurrency_control/read_only_tx/scan/read_only_reverse_scan_test.cpp
+++ b/test/concurrency_control/read_only_tx/scan/read_only_reverse_scan_test.cpp
@@ -1,0 +1,140 @@
+
+#include <xmmintrin.h>
+
+#include <array>
+#include <atomic>
+#include <mutex>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include "atomic_wrapper.h"
+#include "test_tool.h"
+
+#include "concurrency_control/include/epoch.h"
+#include "concurrency_control/include/record.h"
+#include "concurrency_control/include/session.h"
+#include "concurrency_control/include/version.h"
+
+#include "shirakami/interface.h"
+
+#include "yakushima/include/kvs.h"
+
+#include "gtest/gtest.h"
+
+#include "glog/logging.h"
+
+namespace shirakami::testing {
+
+using namespace shirakami;
+
+class read_only_reverse_scan_test : public ::testing::Test { // NOLINT
+public:
+    static void call_once_f() {
+        google::InitGoogleLogging(
+                "shirakami-test-concurrency_control-read_only_tx-"
+                "scan-read_only_reverse_scan_test");
+        // FLAGS_stderrthreshold = 0;
+    }
+
+    void SetUp() override {
+        std::call_once(init_google, call_once_f);
+        init(); // NOLINT
+    }
+
+    void TearDown() override { fin(); }
+
+private:
+    static inline std::once_flag init_google;
+};
+
+TEST_F(read_only_reverse_scan_test, simple) { // NOLINT
+    // verify simple scenario using reverse scan
+    Storage st{};
+    ASSERT_EQ(create_storage("", st), Status::OK);
+    Token s{};
+    ASSERT_EQ(Status::OK, enter(s));
+    // prepare data
+    std::string k0{"k"};
+    std::string v0{"v"};
+    std::string k1{"k1"};
+    std::string v1{"v1"};
+    ASSERT_EQ(Status::OK, tx_begin({s, transaction_options::transaction_type::SHORT}));
+    ASSERT_EQ(Status::OK, upsert(s, st, k0, v0));
+    ASSERT_EQ(Status::OK, upsert(s, st, k1, v1));
+    ASSERT_EQ(Status::OK, commit(s)); // NOLINT
+    ASSERT_EQ(Status::OK, tx_begin({s, transaction_options::transaction_type::READ_ONLY}));
+    wait_epoch_update();
+    ScanHandle hd{};
+    ASSERT_EQ(Status::OK, open_scan(s, st, "", scan_endpoint::INF, "", scan_endpoint::INF, hd, 1, true));
+    std::string sb{};
+    ASSERT_EQ(Status::OK, read_key_from_scan(s, hd, sb));
+    ASSERT_EQ(sb, k1);
+    ASSERT_EQ(Status::OK, read_value_from_scan(s, hd, sb));
+    ASSERT_EQ(sb, v1);
+    ASSERT_EQ(Status::WARN_SCAN_LIMIT, next(s, hd));
+    ASSERT_EQ(Status::OK, commit(s));
+    ASSERT_EQ(Status::OK, leave(s));
+}
+
+TEST_F(read_only_reverse_scan_test, bad_parameters) { // NOLINT
+    // currently reverse scan must be called with max_size == 1 and r_end == INF
+    Storage st{};
+    ASSERT_EQ(create_storage("", st), Status::OK);
+    Token s{};
+    ASSERT_EQ(Status::OK, enter(s));
+    ASSERT_EQ(Status::OK, tx_begin({s, transaction_options::transaction_type::READ_ONLY}));
+    wait_epoch_update();
+    ScanHandle hd{};
+    ASSERT_EQ(Status::ERR_FATAL, open_scan(s, st, "", scan_endpoint::INF, "", scan_endpoint::INF, hd, 0, true));
+    ASSERT_EQ(Status::ERR_FATAL, open_scan(s, st, "", scan_endpoint::INF, "", scan_endpoint::INCLUSIVE, hd, 1, true));
+    ASSERT_EQ(Status::OK, commit(s));
+    ASSERT_EQ(Status::OK, leave(s));
+}
+
+TEST_F(read_only_reverse_scan_test, fail_to_fetch_max_size) { // NOLINT
+    // when maximum rec is tombstone, max_size=1 fails to fetch it
+    Storage st{};
+    ASSERT_EQ(create_storage("", st), Status::OK);
+    Token s{};
+    ASSERT_EQ(Status::OK, enter(s));
+    // prepare data
+    std::string k0{"k"};
+    std::string v0{"v"};
+    std::string k1{"k1"};
+    std::string v1{"v1"};
+    ASSERT_EQ(Status::OK, tx_begin({s, transaction_options::transaction_type::SHORT}));
+    ASSERT_EQ(Status::OK, upsert(s, st, k0, v0));
+    ASSERT_EQ(Status::OK, upsert(s, st, k1, v1));
+    ASSERT_EQ(Status::OK, commit(s)); // NOLINT
+    ASSERT_EQ(Status::OK, tx_begin({s, transaction_options::transaction_type::SHORT}));
+    ASSERT_EQ(Status::OK, delete_record(s, st, k1));
+    ASSERT_EQ(Status::OK, commit(s)); // NOLINT
+
+    {
+        ASSERT_EQ(Status::OK, tx_begin({s, transaction_options::transaction_type::READ_ONLY}));
+        wait_epoch_update();
+        ScanHandle hd{};
+        ASSERT_EQ(Status::WARN_NOT_FOUND, open_scan(s, st, "", scan_endpoint::INF, "", scan_endpoint::INF, hd, 1, true));
+        ASSERT_EQ(Status::OK, commit(s)); // NOLINT
+    }
+
+    {
+        // expecting waiting some epochs fix the problem
+        wait_epoch_update();
+        ASSERT_EQ(Status::OK, tx_begin({s, transaction_options::transaction_type::READ_ONLY}));
+        wait_epoch_update();
+        ScanHandle hd{};
+        ASSERT_EQ(Status::OK, open_scan(s, st, "", scan_endpoint::INF, "", scan_endpoint::INF, hd, 1, true));
+        std::string sb{};
+        ASSERT_EQ(Status::OK, read_key_from_scan(s, hd, sb));
+        ASSERT_EQ(sb, k0);
+        ASSERT_EQ(Status::OK, read_value_from_scan(s, hd, sb));
+        ASSERT_EQ(sb, v0);
+        ASSERT_EQ(Status::WARN_SCAN_LIMIT, next(s, hd));
+        ASSERT_EQ(Status::OK, commit(s)); // NOLINT
+    }
+    ASSERT_EQ(Status::OK, leave(s));
+}
+
+} // namespace shirakami::testing


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1075 実装のためにshirakami open_scan apiにright_to_leftパラメータを追加します。

現状ではyakushima同様、下記の制限つきです。

- max_size = 1 を一緒に渡す必要がある
- r_endにはINFを渡す必要がある

また、max_size = 1によってplaceholder/tombstoneレコードがスキップされることがあり、必ずしも1レコードが取得できないこともありますが、その前提の上で呼び出し側が使うものとします。
