### PR TITLE
new approach for detecting short_tx commit expose across global-epoch switch

### DIFF
--- a/src/concurrency_control/epoch.cpp
+++ b/src/concurrency_control/epoch.cpp
@@ -32,7 +32,7 @@ inline void check_epoch_load_and_update_idle_living_tx() {
     }
 }
 
-inline void check_short_expose_ongoing_status(const epoch_t ce) {
+inline void refresh_short_expose_ongoing_status(const epoch_t ce) {
     epoch_t min_short_expose_ongoing_target_epoch{session::lock_and_epoch_t::UINT63_MASK};
     for (auto&& itr : session_table::get_session_table()) {
         // update short_expose_ongoing_status
@@ -180,7 +180,7 @@ void epoch_thread_work() {
             // change epoch
             auto new_epoch{get_global_epoch() + 1};
             set_global_epoch(new_epoch);
-            check_short_expose_ongoing_status(new_epoch);
+            refresh_short_expose_ongoing_status(new_epoch);
             compute_and_set_cc_safe_ss_epoch();
 #ifdef PWAL
             // change also datastore's epoch

--- a/src/concurrency_control/include/epoch.h
+++ b/src/concurrency_control/include/epoch.h
@@ -40,9 +40,10 @@ inline std::atomic<epoch_t> cc_safe_ss_epoch{// NOLINT
                                              initial_cc_safe_ss_epoch};
 
 /**
- * @brief minimum epoch that OCC might pottentially write to.
+ * @brief minimum epoch that OCC might potentially write to.
+ * @details this is the cache value of min(session::short_expose_ongoing_status.target_epoch).
  */
-inline std::atomic<epoch_t> min_epoch_occ_potentially_write{initial_epoch};
+inline std::atomic<epoch_t> min_epoch_occ_potentially_write{0};
 
 inline std::atomic<epoch_t> datastore_durable_epoch{0}; // NOLINT
 

--- a/src/concurrency_control/include/epoch.h
+++ b/src/concurrency_control/include/epoch.h
@@ -39,6 +39,11 @@ inline std::atomic<std::size_t> global_epoch_time_us{40 * 1000}; // NOLINT
 inline std::atomic<epoch_t> cc_safe_ss_epoch{// NOLINT
                                              initial_cc_safe_ss_epoch};
 
+/**
+ * @brief minimum epoch that OCC might pottentially write to.
+ */
+inline std::atomic<epoch_t> min_epoch_occ_potentially_write{initial_epoch};
+
 inline std::atomic<epoch_t> datastore_durable_epoch{0}; // NOLINT
 
 [[maybe_unused]] inline std::thread epoch_thread; // NOLINT
@@ -69,6 +74,10 @@ inline std::atomic<epoch_t> datastore_durable_epoch{0}; // NOLINT
     return cc_safe_ss_epoch.load(std::memory_order_acquire);
 }
 
+[[maybe_unused]] static epoch_t get_min_epoch_occ_potentially_write() { // NOLINT
+    return min_epoch_occ_potentially_write.load(std::memory_order_acquire);
+}
+
 [[maybe_unused]] static void join_epoch_thread() { epoch_thread.join(); }
 
 [[maybe_unused]] static void set_epoch_thread_end(const bool tf) {
@@ -90,6 +99,10 @@ inline std::atomic<epoch_t> datastore_durable_epoch{0}; // NOLINT
 
 [[maybe_unused]] static void set_cc_safe_ss_epoch(const epoch_t ep) {
     cc_safe_ss_epoch.store(ep, std::memory_order_release);
+}
+
+[[maybe_unused]] static void set_min_epoch_occ_potentially_write(const epoch_t ep) {
+    min_epoch_occ_potentially_write.store(ep, std::memory_order_release);
 }
 
 // For DEBUG and TEST

--- a/src/concurrency_control/include/session.h
+++ b/src/concurrency_control/include/session.h
@@ -62,7 +62,7 @@ public:
      */
     class lock_and_epoch_t {
     public:
-        static const std::uint64_t BIT_MASK = 1UL << 63U;
+        static constexpr std::uint64_t BIT_MASK = 1UL << 63U;
         static constexpr std::uint64_t UINT63_MASK = (1UL << 63U) - 1U;
         [[nodiscard]] bool get_lock() const noexcept {
             return (value_ & BIT_MASK) != 0;
@@ -74,8 +74,8 @@ public:
             return value_;
         }
 
-        lock_and_epoch_t(std::uint64_t value) noexcept : value_(value) {}; // NOLINT
-        lock_and_epoch_t(bool lock, epoch::epoch_t e) noexcept : value_((lock ? BIT_MASK : 0UL) | e) {};
+        lock_and_epoch_t(std::uint64_t value) noexcept : value_(value) {} // NOLINT
+        lock_and_epoch_t(bool lock, epoch::epoch_t e) noexcept : value_((lock ? BIT_MASK : 0UL) | e) {}
         operator std::uint64_t() const noexcept { return value_; } // NOLINT
 
     private:

--- a/src/concurrency_control/interface/start_up.cpp
+++ b/src/concurrency_control/interface/start_up.cpp
@@ -169,6 +169,7 @@ Status init_body(database_options options) { // NOLINT
         }
         epoch::set_global_epoch(new_epoch);
         epoch::set_cc_safe_ss_epoch(new_epoch + 1);
+        epoch::set_min_epoch_occ_potentially_write(0);
         // change also datastore's epoch, this must be after ready()
         switch_epoch(shirakami::datastore::get_datastore(), new_epoch);
 #else

--- a/src/concurrency_control/session.cpp
+++ b/src/concurrency_control/session.cpp
@@ -136,7 +136,7 @@ Status session::find_high_priority_short(bool for_check) const {
     // XXX: this lock is essentially unnecessary, only for compatibility; fix tests first.
 
     for (auto&& itr : session_table::get_session_table()) {
-        if (itr.get_short_expose_ongoing_epoch() < get_valid_epoch()) {
+        if (itr.get_short_expose_ongoing_status().get_target_epoch() < get_valid_epoch()) {
             // logging
             if (VLOG_IS_ON(for_check ? log_debug : log_error)) {
                 std::string str_ltx_id{};

--- a/src/concurrency_control/session.cpp
+++ b/src/concurrency_control/session.cpp
@@ -131,6 +131,10 @@ Status session::find_high_priority_short(bool for_check) const {
         return Status::ERR_FATAL;
     }
 
+    // this is a lock to exclude updating of global epoch
+    std::unique_lock<std::mutex> lk(wp::get_wp_mutex());
+    // XXX: this lock is essentially unnecessary, only for compatibility; fix tests first.
+
     for (auto&& itr : session_table::get_session_table()) {
         if (itr.get_short_expose_ongoing_epoch() < get_valid_epoch()) {
             // logging

--- a/src/concurrency_control/session_table.cpp
+++ b/src/concurrency_control/session_table.cpp
@@ -48,6 +48,7 @@ void session_table::init_session_table() {
         itr.get_lpwal_handle().init();
         itr.get_lpwal_handle().set_worker_number(worker_number);
 #endif
+        itr.clear_short_expose_ongoing_status();
         ++worker_number;
     }
 }


### PR DESCRIPTION
OCC の epoch またぎ操作の検出 (premature check) 方法にタイミングの問題があり、 特定の条件下で、古い epoch から操作を開始して長く続けているトランザクションが突然出現したように見えることがあります。
一度 premature check を通ったのに、後で再度チェックすると通らない、ということは想定されていないため premature check assertion 失敗として shirakami の RTX/LTX 操作が失敗しますが、これは jogasaki から見ると完全に異常動作のため、予期せぬエラーとしてクライアントに返されることになります。

現行の、session object の step_epoch と operating フラグを利用した 最古の OCC操作開始epoch算出関数は、 単調増加性を保証できないため、 これを premature check に使用するとこの問題は避けられません。
(session object が global epoch を読んでから、自分の step_epoch に格納してから operationg をセットするまでの間に 数epoch かかるような状況下では、これが起こりえます)

案件: project-tsurugi/tsurugi-issues#1017

対策として、新たに単調増加する(概念上の)関数を導入して、これを確認に使うようにします。また、epoch またぎが問題となる OCC 側操作は OCC commit expose だけなので、それ以外の OCC 操作は premature check に影響しないようにしました。
