### PR TITLE
insert/update/upsertにblob参照リストを渡せるようにする

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ cppcoreguidelines-*,\
 fuchsia-*,\
 -fuchsia-default-arguments,\
 -fuchsia-default-arguments-calls,\
+-fuchsia-default-arguments-declarations,\
 -fuchsia-overloaded-operator,\
 google-*,\
 -google-build-using-namespace,\

--- a/include/shirakami/interface.h
+++ b/include/shirakami/interface.h
@@ -182,7 +182,11 @@ Status init(database_options options = {}); // NOLINT
  * @param[in] storage the handle of storage.
  * @param[in] key the key of the inserted record
  * @param[in] val the value of the inserted record
- * @param[in] used_blobs the blob references used by the inserted record
+ * @param[in] blobs_data blob references list used by the inserted record.
+ * The blobs will be fully registered on datastore when transaction successfully commits.
+ * Specify nullptr to pass empty list if the inserted record does not contain blob.
+ * @param[in] blobs_size length of the blob references list
+ * Specify 0 to pass empty list.
  * @return Status::ERR_CC Error about concurrency control.
  * @return Status::OK success. If this tx executed delete operation, this insert
  * change the operation into update operation which updates using @a val.
@@ -208,7 +212,8 @@ Status init(database_options options = {}); // NOLINT
 Status insert(Token token, Storage storage,
               std::string_view key, // NOLINT
               std::string_view val,
-              std::vector<blob_id_type> const& used_blobs = {}
+              blob_id_type const* blobs_data = nullptr,
+              std::size_t blobs_size = 0
               );
 
 /**
@@ -396,7 +401,11 @@ Status tx_begin(transaction_options options = {}); // NOLINT
  * @param[in] storage the handle of storage.
  * @param[in] key the key of the updated record
  * @param[in] val the value of the updated record
- * @param[in] used_blobs the blob references used by the updated record
+ * @param[in] blobs_data blob references list used by the updated record.
+ * The blobs will be fully registered on datastore when transaction successfully commits.
+ * Specify nullptr to pass empty list if the updated record does not contain blob.
+ * @param[in] blobs_size length of the blob references list
+ * Specify 0 to pass empty list.
  * @return Status::OK Success.
  * @return Status::WARN_ILLEGAL_OPERATION You execute update on read only
  * mode. So this operation was canceled.
@@ -409,7 +418,8 @@ Status tx_begin(transaction_options options = {}); // NOLINT
  * @return Status::ERR_READ_AREA_VIOLATION error about read area.
  */
 Status update(Token token, Storage storage, std::string_view key, std::string_view val,
-              std::vector<blob_id_type> const& used_blobs = {}); // NOLINT
+              blob_id_type const* blobs_data = nullptr,
+              std::size_t blobs_size = 0); // NOLINT
 
 /**
  * @brief update the record for the given key, or insert the key/value if the
@@ -418,7 +428,11 @@ Status update(Token token, Storage storage, std::string_view key, std::string_vi
  * @param[in] storage the handle of storage.
  * @param[in] key the key of the upserted record
  * @param[in] val the value of the upserted record
- * @param[in] used_blobs the blob references used by the upserted record
+ * @param[in] blobs_data blob references list used by the upserted record.
+ * The blobs will be fully registered on datastore when transaction successfully commits.
+ * Specify nullptr to pass empty list if the upserted record does not contain blob.
+ * @param[in] blobs_size length of the blob references list
+ * Specify 0 to pass empty list.
  * @return Status::ERR_CC Error about concurrency control.
  * @return Status::OK Success
  * @return Status::WARN_ILLEGAL_OPERATION You execute upsert on read only
@@ -434,7 +448,8 @@ Status update(Token token, Storage storage, std::string_view key, std::string_vi
  * this tx is long tx and didn't execute wp for @a storage.
  */
 Status upsert(Token token, Storage storage, std::string_view key, std::string_view val,
-              std::vector<blob_id_type> const& used_blobs = {}); // NOLINT
+              blob_id_type const* blobs_data = nullptr,
+              std::size_t blobs_size = 0); // NOLINT
 
 
 //==========

--- a/include/shirakami/interface.h
+++ b/include/shirakami/interface.h
@@ -182,6 +182,7 @@ Status init(database_options options = {}); // NOLINT
  * @param[in] storage the handle of storage.
  * @param[in] key the key of the inserted record
  * @param[in] val the value of the inserted record
+ * @param[in] used_blobs the blob references used by the inserted record
  * @return Status::ERR_CC Error about concurrency control.
  * @return Status::OK success. If this tx executed delete operation, this insert
  * change the operation into update operation which updates using @a val.
@@ -206,7 +207,9 @@ Status init(database_options options = {}); // NOLINT
  */
 Status insert(Token token, Storage storage,
               std::string_view key, // NOLINT
-              std::string_view val);
+              std::string_view val,
+              std::vector<blob_id_type> const& used_blobs = {}
+              );
 
 /**
  * @brief leave session
@@ -393,6 +396,7 @@ Status tx_begin(transaction_options options = {}); // NOLINT
  * @param[in] storage the handle of storage.
  * @param[in] key the key of the updated record
  * @param[in] val the value of the updated record
+ * @param[in] used_blobs the blob references used by the updated record
  * @return Status::OK Success.
  * @return Status::WARN_ILLEGAL_OPERATION You execute update on read only
  * mode. So this operation was canceled.
@@ -404,8 +408,8 @@ Status tx_begin(transaction_options options = {}); // NOLINT
  * this tx is long tx and didn't execute wp for @a storage.
  * @return Status::ERR_READ_AREA_VIOLATION error about read area.
  */
-Status update(Token token, Storage storage, std::string_view key,
-              std::string_view val); // NOLINT
+Status update(Token token, Storage storage, std::string_view key, std::string_view val,
+              std::vector<blob_id_type> const& used_blobs = {}); // NOLINT
 
 /**
  * @brief update the record for the given key, or insert the key/value if the
@@ -414,6 +418,7 @@ Status update(Token token, Storage storage, std::string_view key,
  * @param[in] storage the handle of storage.
  * @param[in] key the key of the upserted record
  * @param[in] val the value of the upserted record
+ * @param[in] used_blobs the blob references used by the upserted record
  * @return Status::ERR_CC Error about concurrency control.
  * @return Status::OK Success
  * @return Status::WARN_ILLEGAL_OPERATION You execute upsert on read only
@@ -428,8 +433,8 @@ Status update(Token token, Storage storage, std::string_view key,
  * @return Status::WARN_WRITE_WITHOUT_WP This function can't execute because
  * this tx is long tx and didn't execute wp for @a storage.
  */
-Status upsert(Token token, Storage storage, std::string_view key,
-              std::string_view val); // NOLINT
+Status upsert(Token token, Storage storage, std::string_view key, std::string_view val,
+              std::vector<blob_id_type> const& used_blobs = {}); // NOLINT
 
 
 //==========

--- a/include/shirakami/scheme.h
+++ b/include/shirakami/scheme.h
@@ -56,6 +56,12 @@ inline std::ostream& operator<<(std::ostream& out, scan_endpoint op) { // NOLINT
 }
 
 /**
+ * @brief BLOB reference type.
+ * @details the reference type for BLOB data. This must be same as one defined by datastore.
+ */
+using blob_id_type = std::uint64_t;
+
+/**
  * @brief the status which is after some function.
  * OK is success return code.
  * WARN_... is no problem for extra progressing due to work but last command

--- a/src/concurrency_control/interface/insert.cpp
+++ b/src/concurrency_control/interface/insert.cpp
@@ -163,7 +163,8 @@ Status insert_body(Token const token, Storage const storage, // NOLINT
 
 Status insert(Token const token, Storage const storage, // NOLINT
               const std::string_view key,               // NOLINT
-              const std::string_view val) {
+              const std::string_view val,
+              [[maybe_unused]] std::vector<blob_id_type> const& used_blobs) {
     shirakami_log_entry << "insert, token: " << token
                         << ", storage: " << storage << shirakami_binstring(key)
                         << shirakami_binstring(val);

--- a/src/concurrency_control/interface/insert.cpp
+++ b/src/concurrency_control/interface/insert.cpp
@@ -164,7 +164,9 @@ Status insert_body(Token const token, Storage const storage, // NOLINT
 Status insert(Token const token, Storage const storage, // NOLINT
               const std::string_view key,               // NOLINT
               const std::string_view val,
-              [[maybe_unused]] std::vector<blob_id_type> const& used_blobs) {
+              [[maybe_unused]] blob_id_type const* blobs_data,
+              [[maybe_unused]] std::size_t blobs_size) {
+    //TODO implement blobs
     shirakami_log_entry << "insert, token: " << token
                         << ", storage: " << storage << shirakami_binstring(key)
                         << shirakami_binstring(val);

--- a/src/concurrency_control/interface/update.cpp
+++ b/src/concurrency_control/interface/update.cpp
@@ -94,7 +94,9 @@ Status update_body(Token token, Storage storage,
 Status update(Token token, Storage storage,
               std::string_view const key, // NOLINT
               std::string_view const val,
-              [[maybe_unused]] std::vector<blob_id_type> const& used_blobs) {
+              [[maybe_unused]] blob_id_type const* blobs_data,
+              [[maybe_unused]] std::size_t blobs_size) {
+    //TODO implement blobs
     shirakami_log_entry << "update, token: " << token
                         << ", storage: " << storage << shirakami_binstring(key)
                         << shirakami_binstring(val);

--- a/src/concurrency_control/interface/update.cpp
+++ b/src/concurrency_control/interface/update.cpp
@@ -93,7 +93,8 @@ Status update_body(Token token, Storage storage,
 
 Status update(Token token, Storage storage,
               std::string_view const key, // NOLINT
-              std::string_view const val) {
+              std::string_view const val,
+              [[maybe_unused]] std::vector<blob_id_type> const& used_blobs) {
     shirakami_log_entry << "update, token: " << token
                         << ", storage: " << storage << shirakami_binstring(key)
                         << shirakami_binstring(val);

--- a/src/concurrency_control/interface/upsert.cpp
+++ b/src/concurrency_control/interface/upsert.cpp
@@ -142,7 +142,8 @@ Status upsert_body(Token token, Storage storage, const std::string_view key,
 }
 
 Status upsert(Token token, Storage storage, std::string_view const key,
-              std::string_view const val) {
+              std::string_view const val,
+              [[maybe_unused]] std::vector<blob_id_type> const& used_blobs) {
     shirakami_log_entry << "upsert, token: " << token << ", storage; "
                         << storage << shirakami_binstring(key)
                         << shirakami_binstring(val);

--- a/src/concurrency_control/interface/upsert.cpp
+++ b/src/concurrency_control/interface/upsert.cpp
@@ -143,7 +143,9 @@ Status upsert_body(Token token, Storage storage, const std::string_view key,
 
 Status upsert(Token token, Storage storage, std::string_view const key,
               std::string_view const val,
-              [[maybe_unused]] std::vector<blob_id_type> const& used_blobs) {
+              [[maybe_unused]] blob_id_type const* blobs_data,
+              [[maybe_unused]] std::size_t blobs_size) {
+    //TODO implement blobs
     shirakami_log_entry << "upsert, token: " << token << ", storage; "
                         << storage << shirakami_binstring(key)
                         << shirakami_binstring(val);

--- a/test/tsurugi_issues/tsurugi_issue665_test.cpp
+++ b/test/tsurugi_issues/tsurugi_issue665_test.cpp
@@ -213,7 +213,7 @@ TEST_P(tsurugi_issue665_test, // NOLINT
     ASSERT_OK(commit(t));
 
     // prepare write operator
-    std::function<Status(Token, Storage, std::string_view, std::string_view)>
+    std::function<Status(Token, Storage, std::string_view, std::string_view, std::vector<blob_id_type> const&)>
             write;
     if (GetParam()) {
         write = insert;
@@ -270,7 +270,7 @@ TEST_P(tsurugi_issue665_test, // NOLINT
 
             // write st1, st2
             rc = write(t, st1, std::to_string(count + 1),
-                       std::to_string(count + 1));
+                       std::to_string(count + 1), std::vector<blob_id_type>{});
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) { abort(t); }
@@ -280,7 +280,7 @@ TEST_P(tsurugi_issue665_test, // NOLINT
             }
             ASSERT_OK(rc);
             rc = write(t, st2, std::to_string(count + 1),
-                       std::to_string(count + 1));
+                       std::to_string(count + 1), std::vector<blob_id_type>{});
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) { abort(t); }

--- a/test/tsurugi_issues/tsurugi_issue665_test.cpp
+++ b/test/tsurugi_issues/tsurugi_issue665_test.cpp
@@ -213,7 +213,7 @@ TEST_P(tsurugi_issue665_test, // NOLINT
     ASSERT_OK(commit(t));
 
     // prepare write operator
-    std::function<Status(Token, Storage, std::string_view, std::string_view, std::vector<blob_id_type> const&)>
+    std::function<Status(Token, Storage, std::string_view, std::string_view, blob_id_type const*, std::size_t)>
             write;
     if (GetParam()) {
         write = insert;
@@ -270,7 +270,7 @@ TEST_P(tsurugi_issue665_test, // NOLINT
 
             // write st1, st2
             rc = write(t, st1, std::to_string(count + 1),
-                       std::to_string(count + 1), std::vector<blob_id_type>{});
+                       std::to_string(count + 1), nullptr, 0);
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) { abort(t); }
@@ -280,7 +280,7 @@ TEST_P(tsurugi_issue665_test, // NOLINT
             }
             ASSERT_OK(rc);
             rc = write(t, st2, std::to_string(count + 1),
-                       std::to_string(count + 1), std::vector<blob_id_type>{});
+                       std::to_string(count + 1), nullptr, 0);
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) { abort(t); }

--- a/test/tsurugi_issues/tsurugi_issue707_3_test.cpp
+++ b/test/tsurugi_issues/tsurugi_issue707_3_test.cpp
@@ -139,7 +139,7 @@ TEST_P(tsurugi_issue707_3_test, // NOLINT
     ASSERT_OK(commit(t));
 
     // prepare write operator
-    std::function<Status(Token, Storage, std::string_view, std::string_view)>
+    std::function<Status(Token, Storage, std::string_view, std::string_view, std::vector<blob_id_type> const&)>
             write;
     if (GetParam()) {
         write = insert;
@@ -208,7 +208,7 @@ TEST_P(tsurugi_issue707_3_test, // NOLINT
             ASSERT_OK(rc);
 
             // write st1
-            rc = write(t, st1, gen_st1_key(count + 1), gen_st1_key(count + 1));
+            rc = write(t, st1, gen_st1_key(count + 1), gen_st1_key(count + 1), std::vector<blob_id_type>{});
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) {
@@ -232,7 +232,7 @@ TEST_P(tsurugi_issue707_3_test, // NOLINT
             // write st2
             for (std::size_t i = 0; i < st2_insert_unit; ++i) {
                 rc = write(t, st2, gen_st2_key(count + 1, i),
-                           gen_st2_key(count + 1, i));
+                           gen_st2_key(count + 1, i), std::vector<blob_id_type>{});
                 ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS ||
                             rc == Status::OK || rc == Status::ERR_CC);
                 if (rc == Status::WARN_ALREADY_EXISTS) {

--- a/test/tsurugi_issues/tsurugi_issue707_3_test.cpp
+++ b/test/tsurugi_issues/tsurugi_issue707_3_test.cpp
@@ -139,7 +139,7 @@ TEST_P(tsurugi_issue707_3_test, // NOLINT
     ASSERT_OK(commit(t));
 
     // prepare write operator
-    std::function<Status(Token, Storage, std::string_view, std::string_view, std::vector<blob_id_type> const&)>
+    std::function<Status(Token, Storage, std::string_view, std::string_view, blob_id_type const*, std::size_t)>
             write;
     if (GetParam()) {
         write = insert;
@@ -208,7 +208,7 @@ TEST_P(tsurugi_issue707_3_test, // NOLINT
             ASSERT_OK(rc);
 
             // write st1
-            rc = write(t, st1, gen_st1_key(count + 1), gen_st1_key(count + 1), std::vector<blob_id_type>{});
+            rc = write(t, st1, gen_st1_key(count + 1), gen_st1_key(count + 1), nullptr, 0);
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) {
@@ -232,7 +232,7 @@ TEST_P(tsurugi_issue707_3_test, // NOLINT
             // write st2
             for (std::size_t i = 0; i < st2_insert_unit; ++i) {
                 rc = write(t, st2, gen_st2_key(count + 1, i),
-                           gen_st2_key(count + 1, i), std::vector<blob_id_type>{});
+                           gen_st2_key(count + 1, i), nullptr, 0);
                 ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS ||
                             rc == Status::OK || rc == Status::ERR_CC);
                 if (rc == Status::WARN_ALREADY_EXISTS) {

--- a/test/tsurugi_issues/tsurugi_issue707_test.cpp
+++ b/test/tsurugi_issues/tsurugi_issue707_test.cpp
@@ -130,7 +130,7 @@ TEST_P(tsurugi_issue707_test, // NOLINT
     ASSERT_OK(commit(t));
 
     // prepare write operator
-    std::function<Status(Token, Storage, std::string_view, std::string_view, std::vector<blob_id_type> const&)>
+    std::function<Status(Token, Storage, std::string_view, std::string_view, blob_id_type const*, std::size_t)>
             write;
     if (GetParam()) {
         write = insert;
@@ -200,7 +200,7 @@ TEST_P(tsurugi_issue707_test, // NOLINT
 
             // write st1
             rc = write(t, st1, std::to_string(count + 1),
-                       std::to_string(count + 1), std::vector<blob_id_type>{});
+                       std::to_string(count + 1), nullptr, 0);
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) {
@@ -223,7 +223,7 @@ TEST_P(tsurugi_issue707_test, // NOLINT
 
             // write st2
             rc = write(t, st2, std::to_string(count + 1),
-                       std::to_string(count + 1), std::vector<blob_id_type>{});
+                       std::to_string(count + 1), nullptr, 0);
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) {

--- a/test/tsurugi_issues/tsurugi_issue707_test.cpp
+++ b/test/tsurugi_issues/tsurugi_issue707_test.cpp
@@ -130,7 +130,7 @@ TEST_P(tsurugi_issue707_test, // NOLINT
     ASSERT_OK(commit(t));
 
     // prepare write operator
-    std::function<Status(Token, Storage, std::string_view, std::string_view)>
+    std::function<Status(Token, Storage, std::string_view, std::string_view, std::vector<blob_id_type> const&)>
             write;
     if (GetParam()) {
         write = insert;
@@ -200,7 +200,7 @@ TEST_P(tsurugi_issue707_test, // NOLINT
 
             // write st1
             rc = write(t, st1, std::to_string(count + 1),
-                       std::to_string(count + 1));
+                       std::to_string(count + 1), std::vector<blob_id_type>{});
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) {
@@ -223,7 +223,7 @@ TEST_P(tsurugi_issue707_test, // NOLINT
 
             // write st2
             rc = write(t, st2, std::to_string(count + 1),
-                       std::to_string(count + 1));
+                       std::to_string(count + 1), std::vector<blob_id_type>{});
             ASSERT_TRUE(rc == Status::WARN_ALREADY_EXISTS || rc == Status::OK ||
                         rc == Status::ERR_CC);
             if (rc == Status::WARN_ALREADY_EXISTS) {


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/1115 対応のためにinsert/update/upsert APIを拡張してblob_id_typeのリストを渡せるようにします。また、互換性のためにデフォルトパラメータとして追加するので、.clang-tidyでこれを禁止しているルール( `fuchsia-default-arguments-declarations` )を外します。