### PR TITLE
build: fix RPATH settings to work even if libdir is not "lib"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 
 set_target_properties(shirakami
         PROPERTIES
-                INSTALL_RPATH "\$ORIGIN/../lib"
+                INSTALL_RPATH "\$ORIGIN"
                 LIBRARY_OUTPUT_NAME "kvs"
         )
 


### PR DESCRIPTION
Tsurugi が主にサポートしている Ubuntu では、インストールディレクトリの下に `lib` ディレクトリを作成し、そこに共有ライブラリファイルを配置しますが、
RHEL 派生 Linux ディストリビューション等では、これが `lib64` ディレクトリとなるため、 INSTALL_RPATH で指定している場所と異なり起動時に問題となることがあります。

関連案件: project-tsurugi/tsurugi-issues#1066

この問題に対処する修正です。