### PR TITLE
fix range compare in read-area hit check function

### DIFF
--- a/src/concurrency_control/include/read_plan.h
+++ b/src/concurrency_control/include/read_plan.h
@@ -72,6 +72,9 @@ public:
         }
     }
 
+    static bool check_range_overlap(
+            const std::string& w_lkey, const std::string& w_rkey,
+            const std::string& r_lkey, scan_endpoint r_lpoint, const std::string& r_rkey, scan_endpoint r_rpoint);
     static bool check_potential_read_anti(std::size_t tx_id, Token token);
 
     // getter / setter

--- a/src/concurrency_control/read_plan.cpp
+++ b/src/concurrency_control/read_plan.cpp
@@ -16,19 +16,15 @@ bool read_plan::check_range_overlap(
         const std::string& w_lkey, const std::string& w_rkey,
         const std::string& r_lkey, scan_endpoint r_lpoint, const std::string& r_rkey, scan_endpoint r_rpoint) {
     // define write range [], read range ()
-    if (
-            // case: [(])
-            ((w_lkey < r_lkey && r_lpoint != scan_endpoint::INF) &&
-             (w_rkey < r_rkey || r_rpoint == scan_endpoint::INF))
-            // case: ([])
-            || ((r_lkey < w_lkey || r_lpoint == scan_endpoint::INF) &&
-                (w_lkey < r_rkey || r_rpoint == scan_endpoint::INF))
-            // case: ([)]
-            || ((r_lkey < w_lkey || r_lpoint == scan_endpoint::INF) &&
-                (w_rkey < r_rkey && r_rpoint != scan_endpoint::INF))) {
-        return true;
-    }
-    return false;
+    bool no_overlap = (
+            // case: []()
+               (r_lpoint == scan_endpoint::INCLUSIVE && w_rkey < r_lkey)
+            || (r_lpoint == scan_endpoint::EXCLUSIVE && w_rkey <= r_lkey)
+            // case: ()[]
+            || (r_rpoint == scan_endpoint::INCLUSIVE && w_lkey > r_rkey)
+            || (r_rpoint == scan_endpoint::EXCLUSIVE && w_lkey >= r_rkey)
+    );
+    return !no_overlap;
 }
 
 bool read_plan::check_potential_read_anti(std::size_t const tx_id,

--- a/src/concurrency_control/read_plan.cpp
+++ b/src/concurrency_control/read_plan.cpp
@@ -32,12 +32,12 @@ bool read_plan::check_potential_read_anti(std::size_t const tx_id,
             return true;
         }
 
-        for (auto&& elem :
+        for (auto&& st :
              static_cast<session*>(token)->get_write_set().get_storage_map()) {
             // cond3 only nlist
             if (plist.empty()) {
                 // the higher priori ltx is not submitted commit
-                auto itr = nlist.find(elem.first);
+                auto itr = nlist.find(st.first);
                 if (itr == nlist.end()) {
                     // the high priori ltx may read this
                     return true;
@@ -52,20 +52,18 @@ bool read_plan::check_potential_read_anti(std::size_t const tx_id,
                     // storage level
                     if (!std::get<1>(p_elem)) {
                         // it didn't submit commit
-                        if (std::get<0>(p_elem) == elem.first) {
+                        if (std::get<0>(p_elem) == st.first) {
                             // hit
                             return true;
                         }
                     } else {
                         // it submit commit
                         // check conflict storage level
-                        if (std::get<0>(p_elem) == elem.first) {
+                        if (std::get<0>(p_elem) == st.first) {
                             // check key range level
                             // todo: use constant value, not magic number
-                            std::string w_lkey =
-                                    std::get<0>(elem.second); // NOLINT
-                            std::string w_rkey =
-                                    std::get<1>(elem.second);         // NOLINT
+                            std::string w_lkey = std::get<0>(st.second);
+                            std::string w_rkey = std::get<1>(st.second);
                             std::string r_lkey = std::get<2>(p_elem); // NOLINT
                             scan_endpoint r_lpoint =
                                     std::get<3>(p_elem);              // NOLINT


### PR DESCRIPTION
トランザクションの commit 時に、READ AREA を実際に読んだ範囲まで縮小する処理が行われますが、この縮小された READ AREA が他トランザクションの write と衝突するかの判定ルーチン (範囲比較) に誤りがあったため、衝突しないと誤判定されることがありました。
commit での READ AREA 縮小の後に read_by 情報を追加するため、これより後は read_by 情報を使い衝突判定を正しく行えますが、それまでの短い時間の間に、実際には衝突している 低優先度 LTX の commit が abort されないということが起こる可能性があります。

関連案件: project-tsurugi/tsurugi-issues#1107

この対応のため、衝突判定ルーチンを修正しました。