### PR TITLE
open_scan に空の範囲を渡された場合の挙動変更

### DIFF
--- a/include/shirakami/interface.h
+++ b/include/shirakami/interface.h
@@ -228,37 +228,33 @@ Status insert(Token token, Storage storage,
 Status leave(Token token); // NOLINT
 
 /**
- * @brief This function preserve the specified range of masstree. If you use ltx
+ * @brief start scan and return the scan handle for the specified range.
+ * @details This function preserve the specified range of masstree. If you use ltx
  * mode, it may log forwarding and read information.
  * @param[in] token the token retrieved by enter()
  * @param[in] storage the handle of storage.
- * @param[in] l_key the left end key of range.
- * @param[in] l_end whether including the left end key for this range.
- * @param[in] r_key the right end key of range.
- * @param[in] r_end whether including the right end key for this range.
- * @param[out] handle the handle to identify scanned result. This handle will be
- * deleted at abort function or close_scan command.
- * @param[in] max_size Default is 0. If this argument is 0, it will not use
- * this argument. This argument limits the number of results.
- * @attention This scan limits range which is specified by @b l_key, @b l_end,
- * @b r_key, and @b r_end.
+ * @param[in] l_key the left end key of range. This argument is ignored if `l_end` is scan_endpoint::INF.
+ * @param[in] l_end whether the scan range includes the left end key.
+ * @param[in] r_key the right end key of range. This argument is ignored if `r_end` is scan_endpoint::INF.
+ * @param[in] r_end whether the scan range includes the right end key.
+ * @attention Contrary to yakushima where ranges are strictly validated, this function does not return an error for the
+ * invalid range (condition that results in empty set, e.g. l_key > r_key.) and returns WARN_NOT_FOUND instead.
+ * @param[out] handle the handle to identify scanned result. This handle will be deleted at abort function
+ * or close_scan command.
+ * @param[in] max_size limits the number of results. Default is 0. If this argument is 0, there is no limit.
  * @warning current implementation of `max_size` discards placeholder/tombstone records after fetching `max_size`
  * records from yakushima, so it's possible that the actual number of records fetched is less than `max_size` even
  * though there are plenty of records.
- * @param[in] right_to_left if true, the scan starts from right end to left. Otherwise, left end to rigth.
+ * @param[in] right_to_left if true, the scan starts from right end to left. Otherwise, left end to right.
  * When this is set to true, current implementation has following limitation: 1. `max_size` must be set to 1
  * so that at most one entry is hit and returned as scan result 2. r_end must be scan_endpoint::INF so that the scan
  * is performed from unbounded right end. Status::ERR_FATAL is returned if these conditions are not met.
  * @return Status::OK success.
- * @return Status::WARN_INVALID_KEY_LENGTH The @a key is invalid. Key length
- * should be equal or less than 30KB.
- * @return Status::WARN_MAX_OPEN_SCAN The fail due to the limits of number of
- * concurrent open_scan without close_scan.
+ * @return Status::WARN_INVALID_KEY_LENGTH The @a key is invalid. Key length should be equal or less than 30KB.
+ * @return Status::WARN_MAX_OPEN_SCAN The fail due to the limits of number of concurrent open_scan without close_scan.
  * @return Status::WARN_NOT_BEGIN The transaction was not begun.
- * @return Status::WARN_NOT_FOUND The scan couldn't find any records. But But
- * the fact that nothing was read is guaranteed by isolation.
- * @return Status::WARN_PREMATURE In long or read only tx mode, it have to wait
- * for some high priority transactions.
+ * @return Status::WARN_NOT_FOUND The scan couldn't find any records.
+ * @return Status::WARN_PREMATURE In long or read only tx mode, it have to wait for some high priority transactions.
  * @return Status::WARN_STORAGE_NOT_FOUND The storage is not found.
  * @return Status::ERR_CC Error about concurrency control.
  * @return Status::ERR_READ_AREA_VIOLATION error about read area.

--- a/test/concurrency_control/short_tx/scan/open_scan/short_open_scan_test.cpp
+++ b/test/concurrency_control/short_tx/scan/open_scan/short_open_scan_test.cpp
@@ -9,6 +9,8 @@
 
 #include "gtest/gtest.h"
 
+#include "test_tool.h"
+
 namespace shirakami::testing {
 
 using namespace shirakami;
@@ -162,6 +164,34 @@ TEST_F(open_scan_test, multi_open_reading_values) { // NOLINT
 
     ASSERT_EQ(Status::OK, commit(s)); // NOLINT
     ASSERT_EQ(Status::OK, leave(s));
+}
+
+TEST_F(open_scan_test, empty_range) {
+    Storage storage{};
+    create_storage("", storage);
+    Token s{};
+    ASSERT_OK(enter(s));
+    ASSERT_OK(tx_begin({s, transaction_options::transaction_type::SHORT}));
+    ASSERT_OK(insert(s, storage, "a", "val"));
+    ScanHandle handle{};
+    ASSERT_EQ(Status::WARN_NOT_FOUND,
+              open_scan(s, storage,
+                        "b", scan_endpoint::INCLUSIVE,
+                        "a", scan_endpoint::INCLUSIVE, handle));
+    ASSERT_EQ(Status::WARN_NOT_FOUND,
+              open_scan(s, storage,
+                        "a", scan_endpoint::INCLUSIVE,
+                        "a", scan_endpoint::EXCLUSIVE, handle));
+    ASSERT_EQ(Status::WARN_NOT_FOUND,
+              open_scan(s, storage,
+                        "a", scan_endpoint::EXCLUSIVE,
+                        "a", scan_endpoint::EXCLUSIVE, handle));
+    ASSERT_EQ(Status::WARN_NOT_FOUND,
+              open_scan(s, storage,
+                        "a", scan_endpoint::EXCLUSIVE,
+                        "a", scan_endpoint::INCLUSIVE, handle));
+    ASSERT_OK(commit(s));
+    ASSERT_OK(leave(s));
 }
 
 } // namespace shirakami::testing

--- a/test/misc_ut/scan_range_check_test.cpp
+++ b/test/misc_ut/scan_range_check_test.cpp
@@ -73,12 +73,12 @@ TEST_F(scan_range_check_test, irregular) {
     // ("a", "a"); empty with two EXCLUSIVEs
     EXPECT_EQ(Status::WARN_NOT_FOUND, check_empty_scan_range("a", scan_endpoint::EXCLUSIVE, "a", scan_endpoint::EXCLUSIVE));
 
-    // invalid use
-    // inf with non empty key; this implementation treats these as normal inf
-    // EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INF, "a", scan_endpoint::INCLUSIVE));
-    // EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INCLUSIVE, "a", scan_endpoint::INF));
-    // EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INF, "a", scan_endpoint::INF));
-    // EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::INF, "a", scan_endpoint::INF));
+    // legal, but not legitimate
+    // inf with non empty key; treated these as normal inf
+    EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INF, "a", scan_endpoint::INCLUSIVE));
+    EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INCLUSIVE, "a", scan_endpoint::INF));
+    EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INF, "a", scan_endpoint::INF));
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::INF, "a", scan_endpoint::INF));
 }
 
 } // namespace shirakami::testing

--- a/test/misc_ut/scan_range_check_test.cpp
+++ b/test/misc_ut/scan_range_check_test.cpp
@@ -1,0 +1,84 @@
+
+#include "shirakami/interface.h"
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+namespace shirakami {
+    extern Status check_empty_scan_range(const std::string_view l_key, const scan_endpoint l_end,
+                                         const std::string_view r_key, const scan_endpoint r_end);
+}
+
+namespace shirakami::testing {
+
+using namespace shirakami;
+
+class scan_range_check_test : public ::testing::Test {
+public:
+    static void call_once_f() {
+        google::InitGoogleLogging("shirakami-test-misc_ut-scan_range_check_test");
+        // FLAGS_stderrthreshold = 0;
+    }
+
+    void SetUp() override { std::call_once(init_google, call_once_f); }
+
+    void TearDown() override {}
+
+private:
+    static inline std::once_flag init_google;
+};
+
+TEST_F(scan_range_check_test, regular) {
+    // regular non-empty pattern
+    // ["a", "a"]; X = "a"
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::INCLUSIVE, "a", scan_endpoint::INCLUSIVE));
+    // ["a", "b"];
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::INCLUSIVE, "b", scan_endpoint::INCLUSIVE));
+    // ("a", "b")
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::EXCLUSIVE, "b", scan_endpoint::EXCLUSIVE));
+    // ["a", "b")
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::INCLUSIVE, "b", scan_endpoint::EXCLUSIVE));
+    // ("a", "b"]
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::EXCLUSIVE, "b", scan_endpoint::INCLUSIVE));
+    // ["a", inf)
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::INCLUSIVE, "", scan_endpoint::INF));
+    // ("a", inf)
+    EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::EXCLUSIVE, "", scan_endpoint::INF));
+    // (-inf, "b"]
+    EXPECT_EQ(Status::OK, check_empty_scan_range("", scan_endpoint::INF, "b", scan_endpoint::INCLUSIVE));
+    // (-inf, "b")
+    EXPECT_EQ(Status::OK, check_empty_scan_range("", scan_endpoint::INF, "b", scan_endpoint::EXCLUSIVE));
+    // (-inf, inf); full scan
+    EXPECT_EQ(Status::OK, check_empty_scan_range("", scan_endpoint::INF, "", scan_endpoint::INF));
+
+    // regular empty pattern
+    // ["a", "a")
+    EXPECT_EQ(Status::WARN_NOT_FOUND, check_empty_scan_range("a", scan_endpoint::INCLUSIVE, "a", scan_endpoint::EXCLUSIVE));
+
+    // valid but rare pattern
+    // ["", inf); X >= ""; ie. full scan
+    EXPECT_EQ(Status::OK, check_empty_scan_range("", scan_endpoint::INCLUSIVE, "a", scan_endpoint::INF));
+    // ("", inf); X > ""
+    EXPECT_EQ(Status::OK, check_empty_scan_range("", scan_endpoint::EXCLUSIVE, "a", scan_endpoint::INF));
+    // (-inf, ""); X < ""
+    EXPECT_EQ(Status::WARN_NOT_FOUND, check_empty_scan_range("", scan_endpoint::INF, "", scan_endpoint::EXCLUSIVE));
+    // (-inf, ""]; X <= ""; ie. X = ""
+    EXPECT_EQ(Status::OK, check_empty_scan_range("", scan_endpoint::INF, "", scan_endpoint::INCLUSIVE));
+}
+
+TEST_F(scan_range_check_test, irregular) {
+    // invalid range
+    // ["b", "a"]; left > right
+    EXPECT_EQ(Status::WARN_NOT_FOUND, check_empty_scan_range("b", scan_endpoint::INCLUSIVE, "a", scan_endpoint::INCLUSIVE));
+    // ("a", "a"); empty with two EXCLUSIVEs
+    EXPECT_EQ(Status::WARN_NOT_FOUND, check_empty_scan_range("a", scan_endpoint::EXCLUSIVE, "a", scan_endpoint::EXCLUSIVE));
+
+    // invalid use
+    // inf with non empty key; this implementation treats these as normal inf
+    // EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INF, "a", scan_endpoint::INCLUSIVE));
+    // EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INCLUSIVE, "a", scan_endpoint::INF));
+    // EXPECT_EQ(Status::OK, check_empty_scan_range("b", scan_endpoint::INF, "a", scan_endpoint::INF));
+    // EXPECT_EQ(Status::OK, check_empty_scan_range("a", scan_endpoint::INF, "a", scan_endpoint::INF));
+}
+
+} // namespace shirakami::testing


### PR DESCRIPTION
shirakami は open_scan に渡ってきた範囲をそのまま yakushima::scan に渡していましたが、
yakushima は空の範囲の場合に ERR_BAD_USAGE を返すという動きをしていたため、
shirakami の open_scan に空の範囲を渡すと (yakushima の ERR_BAD_USAGE を受けて) ERR_FATAL を返すという動きをしていました。

しかし tsurugidb としては合法的な SQL を受けて、それを解釈した jogasaki から空の範囲での open_scan が呼ばれることがあるため、この ERR_FATAL を返す挙動はやや扱いづらいものでした。

関連案件: project-tsurugi/tsurugi-issues#1117

議論の結果、 yakushima と jogasaki の挙動は変えずに shirakami は空の範囲の open_scan に対しては yakushima を呼ばずに WARN_NOT_FOUND を返すという挙動に変更することになりました。