### PR TITLE
scan 操作に関する内部保存領域を独立化することにより並行競合を低減する

### DIFF
--- a/include/shirakami/scheme.h
+++ b/include/shirakami/scheme.h
@@ -30,7 +30,7 @@ using Token = void*;
 /**
  * @brief Scan Handle
  */
-using ScanHandle = std::size_t;
+using ScanHandle = void*;
 
 enum class scan_endpoint : char {
     EXCLUSIVE,

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -18,12 +18,30 @@ public:
     Storage& get_storage() { return storage_; }
     auto& get_vec() { return vec_; }
     std::size_t& get_scan_index() { return scan_index_; }
+
+    // getter
+    [[nodiscard]] std::string_view get_r_key() const { return r_key_; }
+    [[nodiscard]] scan_endpoint get_r_end() const { return r_end_; }
+
+    // setter
+    void set_r_key(std::string_view r_key) { r_key_ = r_key; }
+    void set_r_end(scan_endpoint r_end) { r_end_ = r_end; }
+
 private:
     Storage storage_{};
     std::vector<std::tuple<const Record*,
                            yakushima::node_version64_body,
                            yakushima::node_version64*>> vec_;
     std::size_t scan_index_{};
+
+    /**
+     * @brief range of right endpoint for ltx
+     * @details if user read to right endpoint till scan limit, shirakami needs
+     * to know this information to log range info.
+     */
+    std::string r_key_{};
+
+    scan_endpoint r_end_{};
 };
 
 class scan_handler {
@@ -52,9 +70,6 @@ public:
                 allocated_.erase(sc);
                 delete sc; // NOLINT
             }
-
-            set_r_key("");
-            set_r_end(scan_endpoint::EXCLUSIVE);
         }
 
         return Status::OK;
@@ -84,18 +99,6 @@ public:
         return Status::OK;
     }
 
-    // getter
-
-    [[nodiscard]] std::string_view get_r_key() const { return r_key_; }
-
-    [[nodiscard]] scan_endpoint get_r_end() const { return r_end_; }
-
-    // setter
-
-    void set_r_key(std::string_view r_key) { r_key_ = r_key; }
-
-    void set_r_end(scan_endpoint r_end) { r_end_ = r_end; }
-
 private:
 
     /**
@@ -107,15 +110,6 @@ private:
      * @brief mutex for allocated set
      */
     std::mutex mtx_allocated_;
-
-    /**
-     * @brief range of right endpoint for ltx
-     * @details if user read to right endpoint till scan limit, shirakami needs
-     * to know this information to log range info.
-     */
-    std::string r_key_{};
-
-    scan_endpoint r_end_{};
 };
 
 } // namespace shirakami

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -38,8 +38,8 @@ public:
                 it = allocated_.erase(it);
             }
         }
-        scan_cache_obj* find(ScanHandle sh) { return static_cast<scan_cache_obj*>(sh); } // NOLINT
-        scan_cache_obj* end() { return nullptr; } // NOLINT
+        //scan_cache_obj* find(ScanHandle sh) { return static_cast<scan_cache_obj*>(sh); } // NOLINT
+        //scan_cache_obj* end() { return nullptr; } // NOLINT
         void erase(scan_cache_obj* o) {
             std::lock_guard lk{mtx_allocated_};
             allocated_.erase(o);
@@ -80,16 +80,31 @@ public:
         {
             // for strand
             //std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
-            auto* itr = get_scan_cache().find(hd);
-            if (itr == get_scan_cache().end()) {
+            auto* sc = static_cast<scan_cache_obj*>(hd);
+            if (check_valid_scan_handle(sc) != Status::OK) {
                 return Status::WARN_INVALID_HANDLE;
             }
-            get_scan_cache().erase(itr);
+            get_scan_cache().erase(sc);
 
             set_r_key("");
             set_r_end(scan_endpoint::EXCLUSIVE);
         }
 
+        return Status::OK;
+    }
+
+    static constexpr bool precise_handle_check = false;
+
+    // NOLINTNEXTLINE
+    Status check_valid_scan_handle(scan_cache_obj* sc) {
+        if constexpr (precise_handle_check) {
+            // unimplemented
+            // check sc is in allocated_
+        } else {
+            if (sc == nullptr) {
+                return Status::WARN_INVALID_HANDLE;
+            }
+        }
         return Status::OK;
     }
 

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -36,7 +36,7 @@ private:
     Storage storage_{};
     std::vector<std::tuple<const Record*,
                            yakushima::node_version64_body,
-                           yakushima::node_version64*>> vec_;
+                           yakushima::node_version64*>> vec_{};
     std::size_t scan_index_{0U};
 
     /**
@@ -65,7 +65,7 @@ public:
         }
     }
 
-    Status clear(scan_cache_obj* sc) {
+    Status delete_scan_cache(scan_cache_obj* sc) {
         if (check_valid_scan_handle(sc) != Status::OK) {
             return Status::WARN_INVALID_HANDLE;
         }
@@ -79,7 +79,7 @@ public:
         return Status::OK;
     }
 
-    scan_cache_obj* allocate() {
+    scan_cache_obj* create_scan_cache() {
         auto* sc = new scan_cache_obj(); // NOLINT
         sc->set_parent(this);
         std::lock_guard lk{mtx_allocated_};
@@ -87,6 +87,8 @@ public:
         return sc;
     }
 
+    // for shirakami user code debugging
+    // note: precise-handle-check may cause concurrent contentions problems
     static constexpr bool precise_handle_check = false;
 
     Status check_valid_scan_handle(scan_cache_obj* sc) {

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -57,30 +57,24 @@ private:
 class scan_handler {
 public:
     void clear() {
-        {
-            // for strand
-            //std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
-            std::lock_guard lk{mtx_allocated_};
-            for (auto it = allocated_.begin(); it != allocated_.end(); ) {
-                delete *it; // NOLINT
-                it = allocated_.erase(it);
-            }
+        // for strand
+        std::lock_guard lk{mtx_allocated_};
+        for (auto it = allocated_.begin(); it != allocated_.end(); ) {
+            delete *it; // NOLINT
+            it = allocated_.erase(it);
         }
     }
 
     Status clear(scan_cache_obj* sc) {
+        if (check_valid_scan_handle(sc) != Status::OK) {
+            return Status::WARN_INVALID_HANDLE;
+        }
         {
             // for strand
-            //std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
-            if (check_valid_scan_handle(sc) != Status::OK) {
-                return Status::WARN_INVALID_HANDLE;
-            }
-            {
-                std::lock_guard lk{mtx_allocated_};
-                allocated_.erase(sc);
-                delete sc; // NOLINT
-            }
+            std::lock_guard lk{mtx_allocated_};
+            allocated_.erase(sc);
         }
+        delete sc; // NOLINT
 
         return Status::OK;
     }

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -26,15 +26,6 @@ private:
     std::size_t scan_index_{};
 };
 
-// deprecated dummy class for transition
-class scanned_storage_set {
-public:
-    Storage get(ScanHandle const hd) { // NOLINT
-        auto* o = static_cast<scan_cache_obj*>(hd);
-        return o->get_storage();
-    }
-};
-
 class scan_handler {
 public:
     // dummy class for transition
@@ -110,10 +101,6 @@ public:
 
     //std::shared_mutex& get_mtx_scan_cache() { return mtx_scan_cache_; }
 
-    scanned_storage_set& get_scanned_storage_set() {
-        return scanned_storage_set_;
-    }
-
     [[nodiscard]] std::string_view get_r_key() const { return r_key_; }
 
     [[nodiscard]] scan_endpoint get_r_end() const { return r_end_; }
@@ -134,14 +121,6 @@ private:
      * @brief mutex for scan cache
      */
     //std::shared_mutex mtx_scan_cache_{};
-
-    /**
-     * @brief scanned storage set.
-     * @details As a result of being scanned, the pointer to the record
-     * is retained. However, it does not retain the scanned storage information
-     * . Without it, you will have problems generating read sets.
-     */
-    scanned_storage_set scanned_storage_set_{};
 
     /**
      * @brief range of right endpoint for ltx

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -13,6 +13,19 @@
 
 namespace shirakami {
 
+class alignas(CACHE_LINE_SIZE) scan_cache_obj {
+public:
+    Storage& get_storage() { return storage_; }
+    auto& get_vec() { return vec_; }
+    std::size_t& get_scan_index() { return scan_index_; }
+private:
+    Storage storage_{};
+    std::vector<std::tuple<const Record*,
+                           yakushima::node_version64_body,
+                           yakushima::node_version64*>> vec_;
+    std::size_t scan_index_{};
+};
+
 class scanned_storage_set {
 public:
     Storage get(ScanHandle const hd) {
@@ -49,16 +62,7 @@ private:
 
 class scan_handler {
 public:
-    using scan_elem_type =
-            std::tuple<Storage,
-                       std::vector<std::tuple<const Record*,
-                                              yakushima::node_version64_body,
-                                              yakushima::node_version64*>>,
-                       std::size_t>;  // the cursor pos
-    using scan_cache_type = std::map<ScanHandle, scan_elem_type>;
-    static constexpr std::size_t scan_cache_storage_pos = 0;
-    static constexpr std::size_t scan_cache_vec_pos = 1;
-    static constexpr std::size_t scan_cache_itr_pos = 2;
+    using scan_cache_type = std::map<ScanHandle, scan_cache_obj>;
 
     void clear() {
         {

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -26,38 +26,13 @@ private:
     std::size_t scan_index_{};
 };
 
+// deprecated dummy class for transition
 class scanned_storage_set {
 public:
     Storage get(ScanHandle const hd) { // NOLINT
-        std::shared_lock<std::shared_mutex> lk{get_mtx()};
-        return map_[hd];
+        auto* o = static_cast<scan_cache_obj*>(hd);
+        return o->get_storage();
     }
-
-    void clear() {
-        std::lock_guard<std::shared_mutex> lk{get_mtx()};
-        map_.clear();
-    }
-
-    void clear(ScanHandle const hd) { // NOLINT
-        // for strand
-        std::lock_guard<std::shared_mutex> lk{get_mtx()};
-        map_.erase(hd);
-    }
-
-    void set(ScanHandle const hd, Storage const st) { // NOLINT
-        std::lock_guard<std::shared_mutex> lk{get_mtx()};
-        map_[hd] = st;
-    };
-
-    std::shared_mutex& get_mtx() { return mtx_; }
-
-private:
-    std::map<ScanHandle, Storage> map_;
-
-    /**
-     * @brief mutex for scanned storage set
-     */
-    std::shared_mutex mtx_{};
 };
 
 class scan_handler {
@@ -108,7 +83,6 @@ public:
             //std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
             get_scan_cache().clear();
         }
-        get_scanned_storage_set().clear();
     }
 
     Status clear(ScanHandle hd) {
@@ -124,9 +98,6 @@ public:
             set_r_key("");
             set_r_end(scan_endpoint::EXCLUSIVE);
         }
-
-        // about scanned storage set
-        scanned_storage_set_.clear(hd);
 
         return Status::OK;
     }

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -105,7 +105,7 @@ public:
     void clear() {
         {
             // for strand
-            std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
+            //std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
             get_scan_cache().clear();
         }
         get_scanned_storage_set().clear();
@@ -114,7 +114,7 @@ public:
     Status clear(ScanHandle hd) {
         {
             // for strand
-            std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
+            //std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
             auto* itr = get_scan_cache().find(hd);
             if (itr == get_scan_cache().end()) {
                 return Status::WARN_INVALID_HANDLE;
@@ -137,7 +137,7 @@ public:
         return scan_cache_;
     }
 
-    std::shared_mutex& get_mtx_scan_cache() { return mtx_scan_cache_; }
+    //std::shared_mutex& get_mtx_scan_cache() { return mtx_scan_cache_; }
 
     scanned_storage_set& get_scanned_storage_set() {
         return scanned_storage_set_;
@@ -162,7 +162,7 @@ private:
     /**
      * @brief mutex for scan cache
      */
-    std::shared_mutex mtx_scan_cache_{};
+    //std::shared_mutex mtx_scan_cache_{};
 
     /**
      * @brief scanned storage set.

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -40,11 +40,10 @@ public:
         }
     }
 
-    Status clear(ScanHandle hd) {
+    Status clear(scan_cache_obj* sc) {
         {
             // for strand
             //std::lock_guard<std::shared_mutex> lk{get_mtx_scan_cache()};
-            auto* sc = static_cast<scan_cache_obj*>(hd);
             if (check_valid_scan_handle(sc) != Status::OK) {
                 return Status::WARN_INVALID_HANDLE;
             }
@@ -61,7 +60,7 @@ public:
         return Status::OK;
     }
 
-    ScanHandle allocate() {
+    scan_cache_obj* allocate() {
         auto* sc = new scan_cache_obj(); // NOLINT
         std::lock_guard lk{mtx_allocated_};
         allocated_.insert(sc);

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -15,15 +15,16 @@ namespace shirakami {
 
 class alignas(CACHE_LINE_SIZE) scan_cache_obj {
 public:
-    Storage& get_storage() { return storage_; }
-    auto& get_vec() { return vec_; }
-    std::size_t& get_scan_index() { return scan_index_; }
-
     // getter
+    [[nodiscard]] Storage get_storage() const { return storage_; }
+    auto& get_vec() { return vec_; }
+    [[nodiscard]] std::size_t get_scan_index() const { return scan_index_; }
+    std::size_t& get_scan_index_ref() { return scan_index_; }
     [[nodiscard]] std::string_view get_r_key() const { return r_key_; }
     [[nodiscard]] scan_endpoint get_r_end() const { return r_end_; }
 
     // setter
+    void set_storage(Storage storage) { storage_ = storage; }
     void set_r_key(std::string_view r_key) { r_key_ = r_key; }
     void set_r_end(scan_endpoint r_end) { r_end_ = r_end; }
 
@@ -32,7 +33,7 @@ private:
     std::vector<std::tuple<const Record*,
                            yakushima::node_version64_body,
                            yakushima::node_version64*>> vec_;
-    std::size_t scan_index_{};
+    std::size_t scan_index_{0U};
 
     /**
      * @brief range of right endpoint for ltx

--- a/src/concurrency_control/include/scan.h
+++ b/src/concurrency_control/include/scan.h
@@ -45,7 +45,7 @@ public:
             allocated_.erase(o);
             delete o; // NOLINT
         }
-        scan_cache_obj& operator[](ScanHandle sh) {return *find(sh);}
+        //scan_cache_obj& operator[](ScanHandle sh) {return *find(sh);}
 
         ScanHandle allocate() {
             auto* n = new scan_cache_obj(); // NOLINT

--- a/src/concurrency_control/interface/scan/close_scan.cpp
+++ b/src/concurrency_control/interface/scan/close_scan.cpp
@@ -22,7 +22,7 @@ namespace shirakami {
 Status close_scan_body(Token const token, ScanHandle const handle) { // NOLINT
     auto* ti = static_cast<session*>(token);
     if (!ti->get_tx_began()) { return Status::WARN_NOT_BEGIN; }
-    return ti->get_scan_handle().clear(handle);
+    return ti->get_scan_handle().clear(static_cast<scan_cache_obj*>(handle));
 }
 
 Status close_scan(Token const token, ScanHandle const handle) { // NOLINT

--- a/src/concurrency_control/interface/scan/close_scan.cpp
+++ b/src/concurrency_control/interface/scan/close_scan.cpp
@@ -22,7 +22,7 @@ namespace shirakami {
 Status close_scan_body(Token const token, ScanHandle const handle) { // NOLINT
     auto* ti = static_cast<session*>(token);
     if (!ti->get_tx_began()) { return Status::WARN_NOT_BEGIN; }
-    return ti->get_scan_handle().clear(static_cast<scan_cache_obj*>(handle));
+    return ti->get_scan_handle().delete_scan_cache(static_cast<scan_cache_obj*>(handle));
 }
 
 Status close_scan(Token const token, ScanHandle const handle) { // NOLINT

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -43,10 +43,10 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
         {
             // take read lock
             //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-            std::size_t& scan_index = sh.get_scan_cache()[handle].get_scan_index();
+            std::size_t& scan_index = sc->get_scan_index();
             ++scan_index;
 
-            auto& scan_buf = sh.get_scan_cache()[handle].get_vec();
+            auto& scan_buf = sc->get_vec();
             // check range of cursor
             if (scan_buf.size() <= scan_index) {
                 scan_index = scan_buf.size(); // stop at scan_buf.size

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -42,7 +42,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
         {
             // take read lock
             std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-            std::size_t& scan_index = sh.get_scan_cache_itr()[handle];
+            std::size_t& scan_index = std::get<scan_handler::scan_cache_itr_pos>(sh.get_scan_cache()[handle]);
             ++scan_index;
 
             auto& scan_buf = std::get<scan_handler::scan_cache_vec_pos>(

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -181,8 +181,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
 /**
  * @pre This is called by only long tx mode
  */
-void check_ltx_scan_range_rp_and_log(Token const token, // NOLINT
-                                     ScanHandle const handle) {
+void check_ltx_scan_range_rp_and_log(Token const token, ScanHandle const handle) { // NOLINT
     auto* ti = static_cast<session*>(token);
     auto& sh = ti->get_scan_handle();
     /**

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -29,7 +29,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
      */
     {
         // take read lock
-        std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
+        //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
         if (sh.get_scan_cache().find(handle) == sh.get_scan_cache().end()) {
             return Status::WARN_INVALID_HANDLE;
         }
@@ -41,7 +41,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
         Record* rec_ptr{};
         {
             // take read lock
-            std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
+            //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
             std::size_t& scan_index = sh.get_scan_cache()[handle].get_scan_index();
             ++scan_index;
 
@@ -189,7 +189,7 @@ void check_ltx_scan_range_rp_and_log(Token const token, ScanHandle const handle)
      */
     {
         // take read lock
-        std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
+        //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
         if (sh.get_scan_cache().find(handle) == sh.get_scan_cache().end()) {
             return;
         }

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -34,7 +34,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
 
     // increment cursor
     for (;;) {
-        std::size_t& scan_index = sc->get_scan_index_ref();
+        auto& scan_index = sc->get_scan_index_ref();
         ++scan_index;
 
         auto& scan_buf = sc->get_vec();

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -207,11 +207,11 @@ void check_ltx_scan_range_rp_and_log(Token const token, ScanHandle const handle)
 
         auto& read_range =
                 std::get<1>(ti->get_overtaken_ltx_set()[wp_meta_ptr]);
-        if (std::get<2>(read_range) < sh.get_r_key()) {
-            std::get<2>(read_range) = sh.get_r_key();
+        if (std::get<2>(read_range) < sc->get_r_key()) {
+            std::get<2>(read_range) = sc->get_r_key();
         }
         // conside only inf
-        if (sh.get_r_end() == scan_endpoint::INF) {
+        if (sc->get_r_end() == scan_endpoint::INF) {
             std::get<3>(read_range) = scan_endpoint::INF;
         }
     }

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -42,11 +42,10 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
         {
             // take read lock
             std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-            std::size_t& scan_index = std::get<scan_handler::scan_cache_itr_pos>(sh.get_scan_cache()[handle]);
+            std::size_t& scan_index = sh.get_scan_cache()[handle].get_scan_index();
             ++scan_index;
 
-            auto& scan_buf = std::get<scan_handler::scan_cache_vec_pos>(
-                    sh.get_scan_cache()[handle]);
+            auto& scan_buf = sh.get_scan_cache()[handle].get_vec();
             // check range of cursor
             if (scan_buf.size() <= scan_index) {
                 scan_index = scan_buf.size(); // stop at scan_buf.size

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -43,7 +43,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
         {
             // take read lock
             //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-            std::size_t& scan_index = sc->get_scan_index();
+            std::size_t& scan_index = sc->get_scan_index_ref();
             ++scan_index;
 
             auto& scan_buf = sc->get_vec();

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -31,7 +31,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
     {
         // take read lock
         //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-        if (sh.get_scan_cache().find(handle) == sh.get_scan_cache().end()) {
+        if (sh.check_valid_scan_handle(sc) != Status::OK) {
             return Status::WARN_INVALID_HANDLE;
         }
     }
@@ -189,7 +189,7 @@ void check_ltx_scan_range_rp_and_log(Token const token, ScanHandle const handle)
     {
         // take read lock
         //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-        if (sh.get_scan_cache().find(handle) == sh.get_scan_cache().end()) {
+        if (sh.check_valid_scan_handle(sc) != Status::OK) {
             return;
         }
     }

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -21,6 +21,7 @@ namespace shirakami {
 
 Status next_body(Token const token, ScanHandle const handle) { // NOLINT
     auto* ti = static_cast<session*>(token);
+    auto* sc = static_cast<scan_cache_obj*>(handle);
     if (!ti->get_tx_began()) { return Status::WARN_NOT_BEGIN; }
 
     auto& sh = ti->get_scan_handle();
@@ -144,10 +145,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
                 /**
                  * short mode must read deleted record and verify, so add read set
                  */
-                auto& sh = ti->get_scan_handle();
-                ti->push_to_read_set_for_stx(
-                        {sh.get_scanned_storage_set().get(handle), rec_ptr,
-                         tid});
+                ti->push_to_read_set_for_stx({sc->get_storage(), rec_ptr, tid});
             }
             if (ti->get_tx_type() ==
                         transaction_options::transaction_type::LONG ||
@@ -183,6 +181,7 @@ Status next_body(Token const token, ScanHandle const handle) { // NOLINT
  */
 void check_ltx_scan_range_rp_and_log(Token const token, ScanHandle const handle) { // NOLINT
     auto* ti = static_cast<session*>(token);
+    auto* sc = static_cast<scan_cache_obj*>(handle);
     auto& sh = ti->get_scan_handle();
     /**
      * Check whether the handle is valid.
@@ -199,8 +198,7 @@ void check_ltx_scan_range_rp_and_log(Token const token, ScanHandle const handle)
     // log full scan
     // get storage info
     wp::wp_meta* wp_meta_ptr{};
-    if (wp::find_wp_meta(sh.get_scanned_storage_set().get(handle),
-                         wp_meta_ptr) != Status::OK) {
+    if (wp::find_wp_meta(sc->get_storage(), wp_meta_ptr) != Status::OK) {
         // todo special case. interrupt DDL
         return;
     }

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -27,7 +27,7 @@ inline Status find_open_scan_slot(session* const ti, // NOLINT
         if (itr == sh.get_scan_cache().end()) {
             out = i;
             // clear cursor info
-            sh.get_scan_cache_itr()[i] = 0;
+            std::get<scan_handler::scan_cache_itr_pos>(sh.get_scan_cache()[i]) = 0;
             return Status::OK;
         }
     }
@@ -420,7 +420,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
         // increment for head skipped records
         // may need mutex for strand
         std::size_t& scan_index =
-                ti->get_scan_handle().get_scan_cache_itr()[handle];
+                std::get<scan_handler::scan_cache_itr_pos>(ti->get_scan_handle().get_scan_cache()[handle]);
         scan_index += head_skip_rec_n;
 
         sh.get_scanned_storage_set().set(handle, storage);

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -395,7 +395,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
     auto& sh = ti->get_scan_handle();
     {
         // lock for strand
-        std::lock_guard<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
+        //std::lock_guard<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
 
         // find slot to log scan result.
         auto rc = find_open_scan_slot(ti, handle);

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -22,7 +22,7 @@ namespace shirakami {
 inline Status find_open_scan_slot(session* const ti, // NOLINT
                                   ScanHandle& out) {
     auto& sh = ti->get_scan_handle();
-    if (auto* i = sh.get_scan_cache().allocate(); i != nullptr) {
+    if (auto* i = sh.allocate(); i != nullptr) {
             out = i;
             // clear cursor info
             static_cast<scan_cache_obj*>(i)->get_scan_index() = 0;

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -417,7 +417,6 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
         std::size_t& scan_index = ti->get_scan_handle().get_scan_cache()[handle].get_scan_index();
         scan_index += head_skip_rec_n;
 
-        sh.get_scanned_storage_set().set(handle, storage);
         sh.set_r_key(r_key);
         sh.set_r_end(r_end);
     }

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -380,7 +380,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
     }
 
     // Cache a pointer to record.
-    auto* sc = ti->get_scan_handle().allocate();
+    auto* sc = ti->get_scan_handle().create_scan_cache();
     if (sc == nullptr) {
         return Status::WARN_MAX_OPEN_SCAN;
     }
@@ -397,7 +397,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
     }
 
     // increment for head skipped records
-    std::size_t& scan_index = sc->get_scan_index_ref();
+    auto& scan_index = sc->get_scan_index_ref();
     scan_index += head_skip_rec_n;
 
     sc->set_r_key(r_key);

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -27,7 +27,7 @@ inline Status find_open_scan_slot(session* const ti, // NOLINT
         if (itr == sh.get_scan_cache().end()) {
             out = i;
             // clear cursor info
-            std::get<scan_handler::scan_cache_itr_pos>(sh.get_scan_cache()[i]) = 0;
+            sh.get_scan_cache()[i].get_scan_index() = 0;
             return Status::OK;
         }
     }
@@ -404,10 +404,8 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
         auto rc = find_open_scan_slot(ti, handle);
         if (rc != Status::OK) { return rc; }
 
-        std::get<scan_handler::scan_cache_storage_pos>(
-                sh.get_scan_cache()[handle]) = storage;
-        auto& vec = std::get<scan_handler::scan_cache_vec_pos>(
-                sh.get_scan_cache()[handle]);
+        sh.get_scan_cache()[handle].get_storage() = storage;
+        auto& vec = sh.get_scan_cache()[handle].get_vec();
         vec.reserve(scan_res.size());
         for (std::size_t i = 0; i < scan_res.size(); ++i) {
             vec.emplace_back(reinterpret_cast<Record*>( // NOLINT
@@ -419,8 +417,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
 
         // increment for head skipped records
         // may need mutex for strand
-        std::size_t& scan_index =
-                std::get<scan_handler::scan_cache_itr_pos>(ti->get_scan_handle().get_scan_cache()[handle]);
+        std::size_t& scan_index = ti->get_scan_handle().get_scan_cache()[handle].get_scan_index();
         scan_index += head_skip_rec_n;
 
         sh.get_scanned_storage_set().set(handle, storage);

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -408,8 +408,8 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
         std::size_t& scan_index = sc->get_scan_index();
         scan_index += head_skip_rec_n;
 
-        sh.set_r_key(r_key);
-        sh.set_r_end(r_end);
+        sc->set_r_key(r_key);
+        sc->set_r_end(r_end);
     }
     return fin_process(ti, Status::OK);
 }

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -22,14 +22,11 @@ namespace shirakami {
 inline Status find_open_scan_slot(session* const ti, // NOLINT
                                   ScanHandle& out) {
     auto& sh = ti->get_scan_handle();
-    for (ScanHandle i = 0;; ++i) {
-        auto itr = sh.get_scan_cache().find(i);
-        if (itr == sh.get_scan_cache().end()) {
+    if (auto* i = sh.get_scan_cache().allocate(); i != nullptr) {
             out = i;
             // clear cursor info
             sh.get_scan_cache()[i].get_scan_index() = 0;
             return Status::OK;
-        }
     }
     return Status::WARN_MAX_OPEN_SCAN;
 }

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -391,8 +391,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
         }
         handle = sc;
 
-        sc->get_scan_index() = 0; // clear cursor info
-        sc->get_storage() = storage;
+        sc->set_storage(storage);
         auto& vec = sc->get_vec();
         vec.reserve(scan_res.size());
         for (std::size_t i = 0; i < scan_res.size(); ++i) {
@@ -405,7 +404,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
 
         // increment for head skipped records
         // may need mutex for strand
-        std::size_t& scan_index = sc->get_scan_index();
+        std::size_t& scan_index = sc->get_scan_index_ref();
         scan_index += head_skip_rec_n;
 
         sc->set_r_key(r_key);

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -57,8 +57,8 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
         }
         // ==========
 
-        auto& scan_buf = sh.get_scan_cache()[handle].get_vec();
-        std::size_t& scan_index = sh.get_scan_cache()[handle].get_scan_index();
+        auto& scan_buf = sc->get_vec();
+        std::size_t& scan_index = sc->get_scan_index();
         if (scan_buf.size() <= scan_index) { return Status::WARN_SCAN_LIMIT; }
         auto itr = scan_buf.begin() + scan_index; // NOLINT
         nv = std::get<1>(*itr);

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -56,9 +56,8 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
         }
         // ==========
 
-        auto& scan_buf = std::get<scan_handler::scan_cache_vec_pos>(
-                sh.get_scan_cache()[handle]);
-        std::size_t& scan_index = std::get<scan_handler::scan_cache_itr_pos>(sh.get_scan_cache()[handle]);
+        auto& scan_buf = sh.get_scan_cache()[handle].get_vec();
+        std::size_t& scan_index = sh.get_scan_cache()[handle].get_scan_index();
         if (scan_buf.size() <= scan_index) { return Status::WARN_SCAN_LIMIT; }
         auto itr = scan_buf.begin() + scan_index; // NOLINT
         nv = std::get<1>(*itr);

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -58,7 +58,7 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
         // ==========
 
         auto& scan_buf = sc->get_vec();
-        std::size_t& scan_index = sc->get_scan_index();
+        std::size_t scan_index = sc->get_scan_index();
         if (scan_buf.size() <= scan_index) { return Status::WARN_SCAN_LIMIT; }
         auto itr = scan_buf.begin() + scan_index; // NOLINT
         nv = std::get<1>(*itr);

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -42,31 +42,21 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
     auto* sc = static_cast<scan_cache_obj*>(handle);
     auto& sh = ti->get_scan_handle();
 
-    Record* rec_ptr{};
-    yakushima::node_version64* nv_ptr{};
-    yakushima::node_version64_body nv{};
-    {
-        // take read lock
-        //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-        // ==========
-        /**
-         * Check whether the handle is valid.
-         */
-        if (sh.check_valid_scan_handle(sc) != Status::OK) {
-            return Status::WARN_INVALID_HANDLE;
-        }
-        // ==========
-
-        auto& scan_buf = sc->get_vec();
-        std::size_t scan_index = sc->get_scan_index();
-        if (scan_buf.size() <= scan_index) { return Status::WARN_SCAN_LIMIT; }
-        auto itr = scan_buf.begin() + scan_index; // NOLINT
-        nv = std::get<1>(*itr);
-        nv_ptr = std::get<2>(*itr);
-
-        // ==========
-        rec_ptr = const_cast<Record*>(std::get<0>(*itr)); // NOLINT
+    /**
+     * Check whether the handle is valid.
+     */
+    if (sh.check_valid_scan_handle(sc) != Status::OK) {
+        return Status::WARN_INVALID_HANDLE;
     }
+
+    auto& scan_buf = sc->get_vec();
+    std::size_t scan_index = sc->get_scan_index();
+    if (scan_buf.size() <= scan_index) { return Status::WARN_SCAN_LIMIT; }
+    auto itr = scan_buf.begin() + scan_index; // NOLINT
+    yakushima::node_version64_body nv = std::get<1>(*itr);
+    yakushima::node_version64* nv_ptr = std::get<2>(*itr);
+
+    Record* rec_ptr = const_cast<Record*>(std::get<0>(*itr)); // NOLINT
 
     // log read range info if ltx
     if (ti->get_tx_type() == transaction_options::transaction_type::LONG) {

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -237,8 +237,8 @@ Status read_key_from_scan(Token const token, ScanHandle const handle, // NOLINT
     return ret;
 }
 
-Status read_value_from_scan(Token const token, // NOLINT
-                            ScanHandle const handle, std::string& value) {
+Status read_value_from_scan(Token const token, ScanHandle const handle, // NOLINT
+                            std::string& value) {
     shirakami_log_entry << "read_value_from_scan, token: " << token
                         << ", handle: " << handle;
     auto* ti = static_cast<session*>(token);

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -58,7 +58,7 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
 
         auto& scan_buf = std::get<scan_handler::scan_cache_vec_pos>(
                 sh.get_scan_cache()[handle]);
-        std::size_t& scan_index = sh.get_scan_cache_itr()[handle];
+        std::size_t& scan_index = std::get<scan_handler::scan_cache_itr_pos>(sh.get_scan_cache()[handle]);
         if (scan_buf.size() <= scan_index) { return Status::WARN_SCAN_LIMIT; }
         auto itr = scan_buf.begin() + scan_index; // NOLINT
         nv = std::get<1>(*itr);

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -46,7 +46,7 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
     yakushima::node_version64_body nv{};
     {
         // take read lock
-        std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
+        //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
         // ==========
         /**
          * Check whether the handle is valid.

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -52,7 +52,7 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
         /**
          * Check whether the handle is valid.
          */
-        if (sh.get_scan_cache().find(handle) == sh.get_scan_cache().end()) {
+        if (sh.check_valid_scan_handle(sc) != Status::OK) {
             return Status::WARN_INVALID_HANDLE;
         }
         // ==========

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -50,7 +50,7 @@ Status read_from_scan(Token token, ScanHandle handle, bool key_read,
     }
 
     auto& scan_buf = sc->get_vec();
-    std::size_t scan_index = sc->get_scan_index();
+    auto scan_index = sc->get_scan_index();
     if (scan_buf.size() <= scan_index) { return Status::WARN_SCAN_LIMIT; }
     auto itr = scan_buf.begin() + scan_index; // NOLINT
     yakushima::node_version64_body nv = std::get<1>(*itr);

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -27,7 +27,7 @@ Status scannable_total_index_size_body(Token const token, ScanHandle const handl
     auto& sh = ti->get_scan_handle();
 
     {
-        std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
+        //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
         if (sh.get_scan_cache().find(handle) == sh.get_scan_cache().end()) {
             /**
              * the handle was invalid.

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -29,7 +29,7 @@ Status scannable_total_index_size_body(Token const token, ScanHandle const handl
 
     {
         //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-        if (sh.get_scan_cache().find(handle) == sh.get_scan_cache().end()) {
+        if (sh.check_valid_scan_handle(sc) != Status::OK) {
             /**
              * the handle was invalid.
              */

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -25,19 +25,15 @@ Status scannable_total_index_size_body(Token const token, ScanHandle const handl
     if (!ti->get_tx_began()) { return Status::WARN_NOT_BEGIN; }
 
     auto* sc = static_cast<scan_cache_obj*>(handle);
-    auto& sh = ti->get_scan_handle();
 
-    {
-        //std::shared_lock<std::shared_mutex> lk{sh.get_mtx_scan_cache()};
-        if (sh.check_valid_scan_handle(sc) != Status::OK) {
-            /**
-             * the handle was invalid.
-             */
-            return Status::WARN_INVALID_HANDLE;
-        }
-
-        size = sc->get_vec().size();
+    if (ti->get_scan_handle().check_valid_scan_handle(sc) != Status::OK) {
+        /**
+         * the handle was invalid.
+         */
+        return Status::WARN_INVALID_HANDLE;
     }
+
+    size = sc->get_vec().size();
     return Status::OK;
 }
 

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -19,8 +19,7 @@
 
 namespace shirakami {
 
-Status scannable_total_index_size_body(Token const token, // NOLINT
-                                       ScanHandle const handle,
+Status scannable_total_index_size_body(Token const token, ScanHandle const handle, // NOLINT
                                        std::size_t& size) {
     auto* ti = static_cast<session*>(token);
     if (!ti->get_tx_began()) { return Status::WARN_NOT_BEGIN; }
@@ -41,8 +40,8 @@ Status scannable_total_index_size_body(Token const token, // NOLINT
     return Status::OK;
 }
 
-Status scannable_total_index_size(Token const token, // NOLINT
-                                  ScanHandle const handle, std::size_t& size) {
+Status scannable_total_index_size(Token const token, ScanHandle const handle, // NOLINT
+                                  std::size_t& size) {
     shirakami_log_entry << "scannable_total_index_size, "
                         << "token: " << token << ", handle: " << handle
                         << ", size: " << size;

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -24,6 +24,7 @@ Status scannable_total_index_size_body(Token const token, ScanHandle const handl
     auto* ti = static_cast<session*>(token);
     if (!ti->get_tx_began()) { return Status::WARN_NOT_BEGIN; }
 
+    auto* sc = static_cast<scan_cache_obj*>(handle);
     auto& sh = ti->get_scan_handle();
 
     {
@@ -35,7 +36,7 @@ Status scannable_total_index_size_body(Token const token, ScanHandle const handl
             return Status::WARN_INVALID_HANDLE;
         }
 
-        size = sh.get_scan_cache()[handle].get_vec().size();
+        size = sc->get_vec().size();
     }
     return Status::OK;
 }

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -36,9 +36,7 @@ Status scannable_total_index_size_body(Token const token, // NOLINT
             return Status::WARN_INVALID_HANDLE;
         }
 
-        size = std::get<scan_handler::scan_cache_vec_pos>(
-                       sh.get_scan_cache()[handle])
-                       .size();
+        size = sh.get_scan_cache()[handle].get_vec().size();
     }
     return Status::OK;
 }

--- a/test/concurrency_control/short_tx/helper/short_helper_tx_begin_test.cpp
+++ b/test/concurrency_control/short_tx/helper/short_helper_tx_begin_test.cpp
@@ -200,7 +200,7 @@ TEST_F(c_helper_tx_begin, short_get_tx_began_) { // NOLINT
     ScanHandle handle = {};
     ASSERT_EQ(Status::OK, open_scan(s, storage, k, scan_endpoint::INCLUSIVE, k,
                                     scan_endpoint::INCLUSIVE, handle));
-    ASSERT_EQ(handle, 0);
+    ASSERT_NE(handle, nullptr);
     ASSERT_EQ(ti->get_tx_began(), true);
     ASSERT_EQ(Status::OK, abort(s));
     ASSERT_EQ(ti->get_tx_began(), false);
@@ -208,7 +208,7 @@ TEST_F(c_helper_tx_begin, short_get_tx_began_) { // NOLINT
               tx_begin({s, transaction_options::transaction_type::SHORT}));
     ASSERT_EQ(Status::OK, open_scan(s, storage, k, scan_endpoint::INCLUSIVE, k,
                                     scan_endpoint::INCLUSIVE, handle));
-    ASSERT_EQ(handle, 0);
+    ASSERT_NE(handle, nullptr);
     ASSERT_EQ(ti->get_tx_began(), true);
     ASSERT_EQ(Status::OK, commit(s));
     // cleanup

--- a/test/concurrency_control/short_tx/scan/next/short_next_test.cpp
+++ b/test/concurrency_control/short_tx/scan/next/short_next_test.cpp
@@ -73,10 +73,10 @@ TEST_F(c_next, next_for_two) { // NOLINT
     ScanHandle hd{};
     ASSERT_EQ(Status::OK, open_scan(s, st, "", scan_endpoint::INF, "",
                                     scan_endpoint::INF, hd));
-    auto* ti = static_cast<session*>(s);
-    auto before_next{ti->get_scan_handle().get_scan_cache()[hd].get_scan_index()};
+    auto* sc = static_cast<scan_cache_obj*>(hd);
+    auto before_next{sc->get_scan_index()};
     ASSERT_EQ(Status::OK, next(s, hd));
-    auto after_next{ti->get_scan_handle().get_scan_cache()[hd].get_scan_index()};
+    auto after_next{sc->get_scan_index()};
     ASSERT_NE(before_next, after_next);
     ASSERT_EQ(Status::WARN_SCAN_LIMIT, next(s, hd));
     ASSERT_EQ(Status::OK, leave(s));

--- a/test/concurrency_control/short_tx/scan/next/short_next_test.cpp
+++ b/test/concurrency_control/short_tx/scan/next/short_next_test.cpp
@@ -74,9 +74,9 @@ TEST_F(c_next, next_for_two) { // NOLINT
     ASSERT_EQ(Status::OK, open_scan(s, st, "", scan_endpoint::INF, "",
                                     scan_endpoint::INF, hd));
     auto* ti = static_cast<session*>(s);
-    auto before_next{ti->get_scan_handle().get_scan_cache_itr()[hd]};
+    auto before_next{std::get<scan_handler::scan_cache_itr_pos>(ti->get_scan_handle().get_scan_cache()[hd])};
     ASSERT_EQ(Status::OK, next(s, hd));
-    auto after_next{ti->get_scan_handle().get_scan_cache_itr()[hd]};
+    auto after_next{std::get<scan_handler::scan_cache_itr_pos>(ti->get_scan_handle().get_scan_cache()[hd])};
     ASSERT_NE(before_next, after_next);
     ASSERT_EQ(Status::WARN_SCAN_LIMIT, next(s, hd));
     ASSERT_EQ(Status::OK, leave(s));

--- a/test/concurrency_control/short_tx/scan/next/short_next_test.cpp
+++ b/test/concurrency_control/short_tx/scan/next/short_next_test.cpp
@@ -74,9 +74,9 @@ TEST_F(c_next, next_for_two) { // NOLINT
     ASSERT_EQ(Status::OK, open_scan(s, st, "", scan_endpoint::INF, "",
                                     scan_endpoint::INF, hd));
     auto* ti = static_cast<session*>(s);
-    auto before_next{std::get<scan_handler::scan_cache_itr_pos>(ti->get_scan_handle().get_scan_cache()[hd])};
+    auto before_next{ti->get_scan_handle().get_scan_cache()[hd].get_scan_index()};
     ASSERT_EQ(Status::OK, next(s, hd));
-    auto after_next{std::get<scan_handler::scan_cache_itr_pos>(ti->get_scan_handle().get_scan_cache()[hd])};
+    auto after_next{ti->get_scan_handle().get_scan_cache()[hd].get_scan_index()};
     ASSERT_NE(before_next, after_next);
     ASSERT_EQ(Status::WARN_SCAN_LIMIT, next(s, hd));
     ASSERT_EQ(Status::OK, leave(s));

--- a/test/concurrency_control/short_tx/scan/open_scan/short_open_scan_test.cpp
+++ b/test/concurrency_control/short_tx/scan/open_scan/short_open_scan_test.cpp
@@ -114,10 +114,11 @@ TEST_F(open_scan_test, multi_open) { // NOLINT
               tx_begin({s, transaction_options::transaction_type::SHORT}));
     ASSERT_EQ(Status::OK, open_scan(s, storage, "", scan_endpoint::INF, "",
                                     scan_endpoint::INF, handle));
-    ASSERT_EQ(0, handle);
+    ASSERT_NE(nullptr, handle);
     ASSERT_EQ(Status::OK, open_scan(s, storage, "", scan_endpoint::INF, "",
                                     scan_endpoint::INF, handle2));
-    ASSERT_EQ(1, handle2);
+    ASSERT_NE(nullptr, handle2);
+    ASSERT_NE(handle, handle2);
     ASSERT_EQ(Status::OK, commit(s)); // NOLINT
     ASSERT_EQ(Status::OK, leave(s));
 }
@@ -144,7 +145,7 @@ TEST_F(open_scan_test, multi_open_reading_values) { // NOLINT
               tx_begin({s, transaction_options::transaction_type::SHORT}));
     ASSERT_EQ(Status::OK, open_scan(s, storage, "a/", scan_endpoint::INCLUSIVE,
                                     "", scan_endpoint::INF, handle));
-    ASSERT_EQ(0, handle);
+    ASSERT_NE(nullptr, handle);
 
     std::string sb{};
     ASSERT_EQ(Status::OK, read_value_from_scan(s, handle, sb));
@@ -152,7 +153,8 @@ TEST_F(open_scan_test, multi_open_reading_values) { // NOLINT
 
     ASSERT_EQ(Status::OK, open_scan(s, storage, "b/", scan_endpoint::INCLUSIVE,
                                     "", scan_endpoint::INF, handle2));
-    ASSERT_EQ(1, handle2);
+    ASSERT_NE(nullptr, handle2);
+    ASSERT_NE(handle, handle2);
     ASSERT_EQ(Status::OK, read_value_from_scan(s, handle2, sb));
     ASSERT_EQ("3", sb);
 

--- a/test/concurrency_control/short_tx/scan/short_close_scan_test.cpp
+++ b/test/concurrency_control/short_tx/scan/short_close_scan_test.cpp
@@ -48,7 +48,7 @@ TEST_F(simple_scan, close_scan) { // NOLINT
     ASSERT_EQ(Status::OK, open_scan(s, storage, "", scan_endpoint::INF, "",
                                     scan_endpoint::INF, handle));
     ASSERT_EQ(Status::OK, close_scan(s, handle));
-    ASSERT_EQ(Status::WARN_INVALID_HANDLE, close_scan(s, handle));
+    //ASSERT_EQ(Status::WARN_INVALID_HANDLE, close_scan(s, handle)); // DISABLED: using handle after close_scan causes UB
     ASSERT_EQ(Status::OK, leave(s));
 }
 

--- a/test/concurrency_control/short_tx/scan/short_missing_close_scan_test.cpp
+++ b/test/concurrency_control/short_tx/scan/short_missing_close_scan_test.cpp
@@ -56,7 +56,7 @@ TEST_F(missing_close_scan_test, read_first) { // NOLINT
         ScanHandle handle{};
         ASSERT_EQ(Status::OK, open_scan(s, storage0, "", scan_endpoint::INF, "",
                                         scan_endpoint::INF, handle));
-        ASSERT_EQ(0, handle);
+        ASSERT_NE(nullptr, handle);
 
         std::string sb{};
         ASSERT_EQ(Status::OK, read_key_from_scan(s, handle, sb));
@@ -86,7 +86,7 @@ TEST_F(missing_close_scan_test, read_second) { // NOLINT
         ScanHandle handle{};
         ASSERT_EQ(Status::OK, open_scan(s, storage0, "", scan_endpoint::INF, "",
                                         scan_endpoint::INF, handle));
-        ASSERT_EQ(0, handle);
+        ASSERT_NE(nullptr, handle);
 
         std::string sb{};
         ASSERT_EQ(Status::OK, read_key_from_scan(s, handle, sb));

--- a/test/concurrency_control/short_tx/scan/short_read_from_scan_test.cpp
+++ b/test/concurrency_control/short_tx/scan/short_read_from_scan_test.cpp
@@ -70,7 +70,7 @@ TEST_F(simple_scan, read_from_scan) { // NOLINT
     ASSERT_EQ(Status::OK, open_scan(s, st, k, scan_endpoint::INCLUSIVE, k4,
                                     scan_endpoint::INCLUSIVE, handle));
     // range : k, k2, k3
-    ASSERT_EQ(Status::WARN_INVALID_HANDLE, read_key_from_scan(s, 3, sb));
+    //ASSERT_EQ(Status::WARN_INVALID_HANDLE, read_key_from_scan(s, 3, sb)); // DISABLED: using a random number as a pointer causes UB
     ASSERT_EQ(Status::OK, open_scan(s, st, k, scan_endpoint::INCLUSIVE, k4,
                                     scan_endpoint::INCLUSIVE, handle));
     // range : k, k2, k3


### PR DESCRIPTION
scan 操作時に yakushima::scan の結果を覚えておくコンテナがありますが、 scan 操作のアクセス (next() / read_key_from_scan() / read_value_from_scan()) のたびに shared_mutex による排他をしてからコンテナへアクセスしているため、 strand による並行操作がかなり遅くなる原因となっています。

関連案件: project-tsurugi/tsurugi-issues#1098

yakushima::scan 結果を コンテナを介して保存するのではなく、独立させ、 ScanHandle を用いて直接アクセスするように変更しました。
ただし、従来からの「close_scan をせずに session を commit/abort してもそこで後始末してくれる」という挙動を維持するために、session 中で open_scan したものを記憶する必要があるため、完全に独立化はしておらず open_scan / close_scan および commit/abort による後始末では排他制御が残っています。
ScanHandle に持たせる情報が変化したため、前は 0 から順に割り振られる小さな整数だとして扱われていたようなテストは通らなくなるため、これらも追従して変更してあります。

* 7844a9fa0371f804da40a30f9759e23acfe9d8fa: 上記の保存領域を独立させる変更
* f00122b4c540fc54e8f81e273e79a8db8e9361e4: 不要となった mutex を除去
* 9b73686ff298b619a399316d208fc52760516259: LTX 用 scan 範囲の保存方法の変更
    * 本件とは直接関係ありませんが、 LTX でのアクセス範囲チェックに用いられることになる scan 範囲の記憶が session につき一つとなっていて、別の scan 中にさらに open_scan をすると上書きされてしまいおかしな挙動となりうる点があったので、併せて修正しています。
* 4a3c1cd2a87e1160dca9c78c1c8a8d968474bd37: 不正な ScanHandle チェックを性能をほとんど落とさない範囲で少し強化
* その他: コード整理整頓
    * cleanup や refactor とコミットコメントに書かれているものはコードの整理・整頓です。