### PR TITLE
RTX でのデータ操作時には API 関数入口の データアクセス/トランザクション終了 排他のための mutex を使わないようにする

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -26,3 +26,11 @@ Shirakami コードから参照する環境変数の説明
     * 未指定時、空文字列指定時には、デフォルト動作をする。
     * `SHIRAKAMI_ENABLE_OCC_EPOCH_LOG_BUFFERING=0` とすると、バッファしない。
     * `SHIRAKAMI_ENABLE_OCC_EPOCH_LOG_BUFFERING=1` とすると、バッファする。
+
+* `SHIRAKAMI_RTX_DA_TERM_MUTEX`
+  * RTX での読み出しデータアクセスとトランザクション終了処理との排他制御処理に関するフラグ。排他制御をするかしないかを選択する。
+    排他制御しない場合には RTX でデータアクセスと並行してトランザクション終了処理を呼び出してはならない。並行で呼び出した場合の動作は未定義となる。
+  * デフォルト動作は排他制御をしない。
+    * 未指定時、空文字列指定時には、デフォルト動作をする。
+    * `SHIRAKAMI_RTX_DA_TERM_MUTEX=0` とすると、排他制御をしない。
+    * `SHIRAKAMI_RTX_DA_TERM_MUTEX=1` とすると、排他制御をする。

--- a/src/concurrency_control/include/session.h
+++ b/src/concurrency_control/include/session.h
@@ -82,6 +82,21 @@ public:
         std::uint64_t value_{};
     };
 
+    class mutex_flags_type {
+    public:
+        using base_int_type = std::uint32_t;
+        static constexpr base_int_type READACCESS_DATERM = 0x00000001U;
+
+        [[nodiscard]] bool do_readaccess_daterm() const {
+            return (flags_ & READACCESS_DATERM) != 0U;
+        }
+        void set_readaccess_daterm(bool b) {
+            if (b) { flags_ |= READACCESS_DATERM; } else { flags_ &= ~READACCESS_DATERM; }
+        }
+
+    private:
+        base_int_type flags_{0U};
+    };
 
     /**
      * @brief call commit callback and clear the callback stored
@@ -309,6 +324,8 @@ public:
     [[nodiscard]] transaction_options::transaction_type get_tx_type() const {
         return tx_type_;
     }
+
+    mutex_flags_type& get_mutex_flags() { return mutex_flags_; }
 
     scan_handler& get_scan_handle() { return scan_handle_; }
 
@@ -708,7 +725,17 @@ public:
 
     // ========== end: node set
 
+    // ========== start: config flags
+    /**
+     * @brief set configuration flags from environ
+     */
     static void set_envflags();
+
+    /**
+     * @brief use da/term mutex if RTX
+     */
+    static inline bool optflag_rtx_da_term_mutex;
+    // ========== end: config flags
 
 private:
     /**
@@ -718,6 +745,11 @@ private:
      */
     std::atomic<transaction_options::transaction_type> tx_type_{
             transaction_options::transaction_type::SHORT};
+
+    /**
+     * @brief control which types of mutex are executed
+     */
+    mutex_flags_type mutex_flags_{};
 
     /**
      * @brief session id used for computing transaction id.

--- a/src/concurrency_control/interface/scan/close_scan.cpp
+++ b/src/concurrency_control/interface/scan/close_scan.cpp
@@ -32,7 +32,8 @@ Status close_scan(Token const token, ScanHandle const handle) { // NOLINT
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
         ret = close_scan_body(token, handle);
     }
     ti->process_before_finish_step();

--- a/src/concurrency_control/interface/scan/close_scan.cpp
+++ b/src/concurrency_control/interface/scan/close_scan.cpp
@@ -33,7 +33,7 @@ Status close_scan(Token const token, ScanHandle const handle) { // NOLINT
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
         ret = close_scan_body(token, handle);
     }
     ti->process_before_finish_step();

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -209,7 +209,8 @@ Status next(Token const token, ScanHandle const handle) { // NOLINT
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
         ret = next_body(token, handle);
         if (ti->get_tx_type() == transaction_options::transaction_type::LONG &&
             ret == Status::WARN_SCAN_LIMIT) {

--- a/src/concurrency_control/interface/scan/next.cpp
+++ b/src/concurrency_control/interface/scan/next.cpp
@@ -210,7 +210,7 @@ Status next(Token const token, ScanHandle const handle) { // NOLINT
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
         ret = next_body(token, handle);
         if (ti->get_tx_type() == transaction_options::transaction_type::LONG &&
             ret == Status::WARN_SCAN_LIMIT) {

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -419,7 +419,7 @@ Status open_scan(Token const token, Storage storage, // NOLINT
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
         ret = open_scan_body(token, storage, l_key, l_end, r_key, r_end, handle,
                              max_size, right_to_left);
     }

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -418,7 +418,8 @@ Status open_scan(Token const token, Storage storage, // NOLINT
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
         ret = open_scan_body(token, storage, l_key, l_end, r_key, r_end, handle,
                              max_size, right_to_left);
     }

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -216,7 +216,7 @@ Status read_key_from_scan(Token const token, ScanHandle const handle, // NOLINT
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
         ret = read_from_scan(token, handle, true, key);
     }
     ti->process_before_finish_step();
@@ -234,7 +234,7 @@ Status read_value_from_scan(Token const token, ScanHandle const handle, // NOLIN
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
         ret = read_from_scan(token, handle, false, value);
     }
     ti->process_before_finish_step();

--- a/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
+++ b/src/concurrency_control/interface/scan/read_kv_from_scan.cpp
@@ -215,7 +215,8 @@ Status read_key_from_scan(Token const token, ScanHandle const handle, // NOLINT
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
         ret = read_from_scan(token, handle, true, key);
     }
     ti->process_before_finish_step();
@@ -232,7 +233,8 @@ Status read_value_from_scan(Token const token, ScanHandle const handle, // NOLIN
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
         ret = read_from_scan(token, handle, false, value);
     }
     ti->process_before_finish_step();

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -47,7 +47,7 @@ Status scannable_total_index_size(Token const token, ScanHandle const handle, //
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
         ret = scannable_total_index_size_body(token, handle, size);
     }
     ti->process_before_finish_step();

--- a/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
+++ b/src/concurrency_control/interface/scan/scannable_total_index_size.cpp
@@ -46,7 +46,8 @@ Status scannable_total_index_size(Token const token, ScanHandle const handle, //
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
         ret = scannable_total_index_size_body(token, handle, size);
     }
     ti->process_before_finish_step();

--- a/src/concurrency_control/interface/search.cpp
+++ b/src/concurrency_control/interface/search.cpp
@@ -67,7 +67,8 @@ Status exist_key(Token const token, Storage const storage, // NOLINT
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
         ret = exist_key_body(token, storage, key);
     }
     ti->process_before_finish_step();
@@ -123,7 +124,8 @@ Status search_key(Token const token, Storage const storage, // NOLINT
     ti->process_before_start_step();
     Status ret{};
     { // for strand
-        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term()};
+        std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
+        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
 
         // search_key_body check warn not begin by concurrent strand
         ret = search_key_body(token, storage, key, value);

--- a/src/concurrency_control/interface/search.cpp
+++ b/src/concurrency_control/interface/search.cpp
@@ -68,7 +68,7 @@ Status exist_key(Token const token, Storage const storage, // NOLINT
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
         ret = exist_key_body(token, storage, key);
     }
     ti->process_before_finish_step();
@@ -125,7 +125,7 @@ Status search_key(Token const token, Storage const storage, // NOLINT
     Status ret{};
     { // for strand
         std::shared_lock<std::shared_mutex> lock{ti->get_mtx_state_da_term(), std::defer_lock};
-        if (ti->get_tx_type() != transaction_options::transaction_type::READ_ONLY) { lock.lock(); }
+        if (ti->get_mutex_flags().do_readaccess_daterm()) { lock.lock(); }
 
         // search_key_body check warn not begin by concurrent strand
         ret = search_key_body(token, storage, key, value);

--- a/src/concurrency_control/interface/tx_begin.cpp
+++ b/src/concurrency_control/interface/tx_begin.cpp
@@ -100,6 +100,12 @@ Status tx_begin_body(transaction_options options) { // NOLINT
         ti->set_diag_tx_state_kind(TxState::StateKind::WAITING_START);
     }
 
+    // select required mutex
+    auto& mflags = ti->get_mutex_flags();
+    mflags.set_readaccess_daterm(
+            (tx_type != transaction_options::transaction_type::READ_ONLY) // if not RTX -> true
+            || session::optflag_rtx_da_term_mutex); // if RTX -> optflag_rtx_da_term_mutex
+
     /**
      * This is for concurrent programming. It teaches to other thread that this
      * tx began at last.

--- a/src/concurrency_control/session.cpp
+++ b/src/concurrency_control/session.cpp
@@ -210,6 +210,25 @@ void session::set_envflags() {
     VLOG(log_debug) << log_location_prefix << "optflag: OCC epoch buffering "
                     << (enable_occ_epoch_buff ? "on" : "off");
 #endif
+
+    // check environ "SHIRAKAMI_RTX_DA_TERM_MUTEX"
+    bool rtx_da_term_mutex = false;
+    if (auto* envstr = std::getenv("SHIRAKAMI_RTX_DA_TERM_MUTEX");
+        envstr != nullptr && *envstr != '\0') {
+        if (std::strcmp(envstr, "1") == 0) {
+            rtx_da_term_mutex = true;
+        } else if (std::strcmp(envstr, "0") == 0) {
+            rtx_da_term_mutex = false;
+        } else {
+            VLOG(log_debug)
+                    << log_location_prefix << "invalid value is set for "
+                    << "SHIRAKAMI_RTX_DA_TERM_MUTEX; using default value";
+        }
+    }
+    optflag_rtx_da_term_mutex = rtx_da_term_mutex;
+
+    VLOG(log_debug) << log_location_prefix << "optflag: RTX da/term mutex "
+                    << (optflag_rtx_da_term_mutex ? "on" : "off");
 }
 
 // ========== end: result info


### PR DESCRIPTION
shirakami は データアクセス処理 API 関数呼出と並行して トランザクション終了処理 API 関数を呼ばれてもガードするように 関数の入り口で (データアクセス/トランザクション終了 排他のための mutex を用いて) 排他制御するようにしていました。
しかし、この排他処理は strand による並行操作がかなり遅くなる原因となっています。

関連案件: project-tsurugi/tsurugi-issues#1098

shirakami の主要ユーザである jogasaki が、 呼び出し元での整流を実装し、データアクセス/トランザクション終了を並行で呼ばないように準備を進めていること、および、 jogasaki が RTX の scan処理を分割して shirakami の strand による並行処理に渡した際の性能を向上したいという要請から、RTX の場合に限り mutex による排他制御をしないように変更しました。
また、デフォルト挙動としてはそのように排他制御しない側に倒しましたが、開発者向けオプション (環境変数経由) でもとのように排他制御するモードでも動かせるようにしました。

RTX のみに限っている理由は、データアクセス処理の内部 abort が関係しています。
strand で データ操作の並行性を上げることが目的であるため、jogasaki の整流実装後もデータアクセス同士の並行アクセスは引き続き発生しますが、このとき片側が内部 abort となってしまうと、このことにより並行 データアクセス/トランザクション終了 が起きてしまいます。
RTX ではその設計上、内部 abort が発生しないためこの問題が起きません。
