### PR TITLE
session::step_epoch メンバ変数の廃止

### DIFF
--- a/src/concurrency_control/epoch.cpp
+++ b/src/concurrency_control/epoch.cpp
@@ -22,16 +22,6 @@
 
 namespace shirakami::epoch {
 
-inline void check_epoch_load_and_update_idle_living_tx() {
-    auto ce{epoch::get_global_epoch()};
-    for (auto&& itr : session_table::get_session_table()) {
-        if (itr.get_operating().load(std::memory_order_acquire) == 0) {
-            // this session is not processing now.
-            if (itr.get_step_epoch() < ce) { itr.set_step_epoch(ce); }
-        }
-    }
-}
-
 inline void refresh_short_expose_ongoing_status(const epoch_t ce) {
     epoch_t min_short_expose_ongoing_target_epoch{session::lock_and_epoch_t::UINT63_MASK};
     for (auto&& itr : session_table::get_session_table()) {
@@ -193,7 +183,6 @@ void epoch_thread_work() {
             }
             // dtor : release wp_mutex
         }
-        check_epoch_load_and_update_idle_living_tx();
     }
 }
 

--- a/src/concurrency_control/include/session.h
+++ b/src/concurrency_control/include/session.h
@@ -333,10 +333,6 @@ public:
         return begin_epoch_.load(std::memory_order_acquire);
     }
 
-    [[nodiscard]] epoch::epoch_t get_step_epoch() const {
-        return step_epoch_.load(std::memory_order_acquire);
-    }
-
     [[nodiscard]] lock_and_epoch_t get_short_expose_ongoing_status() const {
         return short_expose_ongoing_status_.load(std::memory_order_acquire);
     }
@@ -425,8 +421,6 @@ public:
     // ========== end: getter
 
     void process_before_start_step() {
-        // make sure that step_epoch is set when operating becomes 0 to 1
-        set_step_epoch(epoch::get_global_epoch());
         get_operating()++;
     }
 
@@ -608,10 +602,6 @@ public:
 
     void set_begin_epoch(epoch::epoch_t e) {
         begin_epoch_.store(e, std::memory_order_release);
-    }
-
-    void set_step_epoch(epoch::epoch_t e) {
-        step_epoch_.store(e, std::memory_order_release);
     }
 
     void lock_short_expose_ongoing() {
@@ -843,6 +833,7 @@ private:
      * @brief The stx's step epoch used for judge whether a ltx can start.
      * @attention For internal. Don't clear at tx termination. This is used for
      * lock-free coordination for multi-threads.
+     * @deprecated not used any more, to be removed.
      */
     std::atomic<epoch::epoch_t> step_epoch_{epoch::initial_epoch};
 

--- a/src/concurrency_control/interface/scan/open_scan.cpp
+++ b/src/concurrency_control/interface/scan/open_scan.cpp
@@ -230,7 +230,7 @@ Status open_scan_body(Token const token, Storage storage, // NOLINT
          */
         auto wps = wp::find_wp(storage);
         auto find_min_ep{wp::wp_meta::find_min_ep(wps)};
-        if (find_min_ep != 0 && find_min_ep <= ti->get_step_epoch()) {
+        if (find_min_ep != 0 && find_min_ep <= epoch::get_global_epoch()) {
             short_tx::abort(ti);
             std::unique_lock<std::mutex> lk{ti->get_mtx_result_info()};
             ti->get_result_info().set_storage_name(storage);

--- a/src/concurrency_control/interface/short_tx/search.cpp
+++ b/src/concurrency_control/interface/short_tx/search.cpp
@@ -23,7 +23,7 @@ inline Status wp_verify(session* const ti, Storage const st) {
     if (rc != Status::OK) { return Status::WARN_STORAGE_NOT_FOUND; }
     auto wps{wm->get_wped()};
     auto find_min_ep{wp::wp_meta::find_min_ep(wps)};
-    if (find_min_ep != 0 && find_min_ep <= ti->get_step_epoch()) {
+    if (find_min_ep != 0 && find_min_ep <= epoch::get_global_epoch()) {
         std::unique_lock<std::mutex> lk{ti->get_mtx_termination()};
         short_tx::abort(ti);
         ti->set_result(reason_code::CC_OCC_WP_VERIFY);

--- a/test/concurrency_control/epoch_no_stop_test.cpp
+++ b/test/concurrency_control/epoch_no_stop_test.cpp
@@ -44,32 +44,31 @@ TEST_F(epoch_no_stop_test, sleep_to_watch_change_epoch) { // NOLINT
     LOG(INFO) << "first epoch " << first << ", second epoch " << second;
 }
 
-TEST_F(epoch_no_stop_test,                          // NOLINT
-       check_progress_of_step_epoch_by_bg_thread) { // NOLINT
+TEST_F(epoch_no_stop_test, check_progress_of_short_expose_ongoing_target_epoch_by_bg_thread) { // NOLINT
     Token s{};
     ASSERT_EQ(Status::OK, enter(s));
     auto* ti{static_cast<session*>(s)};
-    auto first_epoch{ti->get_step_epoch()};
-    auto second_epoch{ti->get_step_epoch()};
+    auto first_epoch{ti->get_short_expose_ongoing_status().get_target_epoch()};
+    auto second_epoch{ti->get_short_expose_ongoing_status().get_target_epoch()};
     while (first_epoch == second_epoch) {
         _mm_pause();
-        second_epoch = ti->get_step_epoch();
+        second_epoch = ti->get_short_expose_ongoing_status().get_target_epoch();
     }
     LOG(INFO) << first_epoch << " " << second_epoch;
     ASSERT_EQ(Status::OK, leave(s));
 }
 
-TEST_F(epoch_no_stop_test,                                   // NOLINT
-       check_not_progress_of_step_epoch_if_operating_true) { // NOLINT
+TEST_F(epoch_no_stop_test, check_not_progress_of_short_expose_ongoing_target_epoch_if_exposing) { // NOLINT
     Token s{};
     ASSERT_EQ(Status::OK, enter(s));
     auto* ti{static_cast<session*>(s)};
-    ti->set_operating(1);
-    auto first_epoch{ti->get_step_epoch()};
+    ti->lock_short_expose_ongoing();
+    auto first_epoch{ti->get_short_expose_ongoing_status().get_target_epoch()};
     sleepUs(epoch::get_global_epoch_time_us() * 2);
-    auto second_epoch{ti->get_step_epoch()};
+    auto second_epoch{ti->get_short_expose_ongoing_status().get_target_epoch()};
     ASSERT_EQ(first_epoch, second_epoch);
     LOG(INFO) << first_epoch << " " << second_epoch;
+    ti->unlock_short_expose_ongoing_and_refresh_epoch();
     ASSERT_EQ(Status::OK, leave(s));
 }
 

--- a/test/concurrency_control/session_test.cpp
+++ b/test/concurrency_control/session_test.cpp
@@ -85,7 +85,7 @@ TEST_F(session_test, member_operating) { // NOLINT
     ASSERT_EQ(Status::OK, leave(s));
 }
 
-TEST_F(session_test, member_step_epoch_after_each_api) { // NOLINT
+TEST_F(session_test, member_short_expose_ongoing_target_epoch_after_each_api) { // NOLINT
     Token s{};
     ASSERT_EQ(Status::OK, enter(s));
     // prepare data
@@ -98,10 +98,10 @@ TEST_F(session_test, member_step_epoch_after_each_api) { // NOLINT
 
     // test
     auto* ti{static_cast<session*>(s)};
-    auto wait_change_step_epoch = [ti]() {
-        auto ce{ti->get_step_epoch()};
+    auto wait_change_short_expose_ongoing_target_epoch = [ti]() {
+        auto ce{ti->get_short_expose_ongoing_status().get_target_epoch()};
         for (;;) {
-            auto ne{ti->get_step_epoch()};
+            auto ne{ti->get_short_expose_ongoing_status().get_target_epoch()};
             if (ce != ne) {
                 LOG(INFO) << ce << " " << ne;
                 break;
@@ -110,39 +110,39 @@ TEST_F(session_test, member_step_epoch_after_each_api) { // NOLINT
         }
     };
     ASSERT_EQ(Status::OK, tx_begin({s}));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK, commit(s)); // NOLINT
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::WARN_NOT_BEGIN, abort(s));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK,
               tx_begin({s, transaction_options::transaction_type::SHORT}));
     ASSERT_EQ(Status::OK, insert(s, st, "k", ""));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK, update(s, st, "k", ""));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK, upsert(s, st, "k", ""));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::WARN_CANCEL_PREVIOUS_INSERT, delete_record(s, st, "k"));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     std::string sb{};
     ASSERT_EQ(Status::OK, search_key(s, st, "", sb));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK, exist_key(s, st, ""));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ScanHandle hd{};
     ASSERT_EQ(Status::OK, open_scan(s, st, "", scan_endpoint::INF, "",
                                     scan_endpoint::INF, hd));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK, read_key_from_scan(s, hd, sb));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK, read_value_from_scan(s, hd, sb));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::WARN_SCAN_LIMIT, next(s, hd));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     std::size_t sz{};
     ASSERT_EQ(Status::OK, scannable_total_index_size(s, hd, sz));
-    wait_change_step_epoch();
+    wait_change_short_expose_ongoing_target_epoch();
     ASSERT_EQ(Status::OK, leave(s));
 }
 


### PR DESCRIPTION
shirakami の session オブジェクトのメンバ変数に step_epoch というものがあり、以前は Record GC の境界値判定、 OCC の epoch またぎ操作の存在判定に使われていましたが、 Record GC の境界判定は新たに導入された begin_epoch で、 epoch またぎ操作の存在判定も別の機構 (#164) で置き換えられ、残っているのは OCC WP verify による early abort の判定のみとなっています。
API 関数の入り口でこの step_epoch の変数更新が行なわれていますが、これが strand による並行操作が遅くなる原因となっています。

関連案件: project-tsurugi/tsurugi-issues#1098

残っている OCC WP verify による early abort の判定は step_epoch を使わなくても current epoch の値で代用できるため、そちらを使うように変更し、 step_epoh を廃止します。
(current epoch は、将来的には session local epoch のような値を用いたいですが、現在はそのようなものがないため、 global epoch を読みに行きます)

廃止された step_epoch の定義を消すと session class 構造のメモリ配置が変わるため、予期せぬパフォーマンス影響が発生するかもしれませんので、後日慎重に消すことにします。