### PR TITLE
session::operating メンバ変数の廃止

### DIFF
--- a/src/concurrency_control/interface/session_management.cpp
+++ b/src/concurrency_control/interface/session_management.cpp
@@ -60,10 +60,6 @@ void assert_before_unlock(session* const ti) {
     if (ti->get_tx_began()) {
         LOG_FIRST_N(ERROR, 1) << log_location_prefix << "tx began at leave";
     }
-    if (ti->get_operating().load(std::memory_order_acquire) != 0) {
-        LOG_FIRST_N(ERROR, 1)
-                << log_location_prefix << "operating is not zero at leave";
-    }
 }
 
 void unlock_for_other_client(session* const ti) {

--- a/src/concurrency_control/session_table.cpp
+++ b/src/concurrency_control/session_table.cpp
@@ -36,8 +36,6 @@ void session_table::init_session_table() {
         itr.set_higher_tx_counter(0);
         itr.set_tx_counter(0);
         itr.set_session_id(worker_number);
-        // for strand
-        itr.set_operating(0);
         // for commit callback
         itr.set_commit_callback({});
         // for mrc tid

--- a/test/concurrency_control/session_test.cpp
+++ b/test/concurrency_control/session_test.cpp
@@ -34,57 +34,6 @@ private:
     static inline std::once_flag init_; // NOLINT
 };
 
-TEST_F(session_test, member_operating) { // NOLINT
-    Token s{};
-    ASSERT_EQ(Status::OK, enter(s));
-    // prepare data
-    Storage st{};
-    ASSERT_EQ(Status::OK, create_storage("", st));
-    ASSERT_EQ(Status::OK,
-              tx_begin({s, transaction_options::transaction_type::SHORT}));
-    ASSERT_EQ(Status::OK, upsert(s, st, "", ""));
-    ASSERT_EQ(Status::OK, commit(s)); // NOLINT
-
-    // test
-    auto* ti{static_cast<session*>(s)};
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, tx_begin({s}));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, commit(s)); // NOLINT
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::WARN_NOT_BEGIN, abort(s));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK,
-              tx_begin({s, transaction_options::transaction_type::SHORT}));
-    ASSERT_EQ(Status::OK, insert(s, st, "k", ""));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, update(s, st, "k", ""));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, upsert(s, st, "k", ""));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::WARN_CANCEL_PREVIOUS_INSERT, delete_record(s, st, "k"));
-    ASSERT_EQ(ti->get_operating(), 0);
-    std::string sb{};
-    ASSERT_EQ(Status::OK, search_key(s, st, "", sb));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, exist_key(s, st, ""));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ScanHandle hd{};
-    ASSERT_EQ(Status::OK, open_scan(s, st, "", scan_endpoint::INF, "",
-                                    scan_endpoint::INF, hd));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, read_key_from_scan(s, hd, sb));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, read_value_from_scan(s, hd, sb));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::WARN_SCAN_LIMIT, next(s, hd));
-    ASSERT_EQ(ti->get_operating(), 0);
-    std::size_t sz{};
-    ASSERT_EQ(Status::OK, scannable_total_index_size(s, hd, sz));
-    ASSERT_EQ(ti->get_operating(), 0);
-    ASSERT_EQ(Status::OK, leave(s));
-}
-
 TEST_F(session_test, member_short_expose_ongoing_target_epoch_after_each_api) { // NOLINT
     Token s{};
     ASSERT_EQ(Status::OK, enter(s));


### PR DESCRIPTION
shirakami の session オブジェクトのメンバ変数に operating というものがあり、API 関数の出入口でこの変数更新が atomic RMW で行なわれていますが、これが strand による並行操作がかなり遅くなる原因となっています。

関連案件: project-tsurugi/tsurugi-issues#1098

この変数は以前は OCC の操作タイミングに関する確認等に使用されていましたが、 #173 やそれ以前の変更に利用されなくなりました。
あとは、以前にshirakami 内部で operating 操作に不備があった際にそれに気づけるようにするために導入された、 leave() 内でのチェックおよびテストコードのみが残されていますが、そのような不備が起こりにくいコード構成に整えられたので、そのチェックも意味を失っていました。 (project-tsurugi/tsurugi-issues#310)
 (また、仮に変数操作が誤っていたとしても何からも利用されていないので悪影響がない)

以上の理由より、この変数を廃止します。

廃止された operating の定義を消すと session class 構造のメモリ配置が変わるため、予期せぬパフォーマンスへの影響が発生するかもしれませんので、後日慎重に消すことにします。

#170, #172 (RTX), #173 および本件の変更で strand による並行操作が遅くなる主要な原因を除去できるため、 RTX での strand 利用が性能よくスケールするようになることが期待されます。