### PR TITLE
build: add build option `BUILD_STRICT`

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -7,6 +7,9 @@ inputs:
   path:
     description: Relative path under $GITHUB_WORKSPACE to place the repository
     default: build-deps
+  cmake_build_option:
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -34,7 +37,7 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash
 
@@ -44,6 +47,6 @@ runs:
         rm -fr build
         mkdir build
         cd build
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ..
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=OFF -DBUILD_DOCUMENTS=OFF -DBUILD_BENCHMARK=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local ${{ inputs.cmake_build_option }} ..
         cmake --build . --target install --clean-first
       shell: bash

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,9 @@ on:
       os:
         type: string
         default: 'ubuntu-22.04'
+      cmake_build_option:
+        type: string
+        default: ''
 
 jobs:
   Test:
@@ -38,12 +41,14 @@ jobs:
 
       - name: Install_Dependencies
         uses: ./.github/actions/install-dependencies
+        with:
+          cmake_build_option: ${{ inputs.cmake_build_option }}
 
       - name: CMake_Build
         run: |
           mkdir -p build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DBUILD_PWAL=ON ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DBUILD_PWAL=ON ${{ inputs.cmake_build_option }} ..
           cmake --build . --target all --clean-first
 
       - name: CTest_CC
@@ -104,12 +109,14 @@ jobs:
 
       - name: Install_Dependencies
         uses: ./.github/actions/install-dependencies
+        with:
+          cmake_build_option: ${{ inputs.cmake_build_option }}
 
       - name: CMake_Generate
         run: |
           mkdir -p build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DBUILD_PWAL=ON ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/.local -DBUILD_PWAL=ON ${{ inputs.cmake_build_option }} ..
 
       - name: Clang-Tidy
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(ENABLE_SANITIZER "enable sanitizer on debug build" ON)
 option(ENABLE_UB_SANITIZER "enable undefined behavior sanitizer on debug build" OFF)
 option(ENABLE_COVERAGE "enable coverage on debug build" OFF)
 option(BUILD_SHARED_LIBS "build shared libraries instead of static" ON)
+option(BUILD_STRICT "build with option strictly determine of success" ON)
 
 # transaction processing logic
 option(BUILD_PWAL "Build parallel write ahead logging as logging." ON)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Available options:
    * Never build documents by doxygen (default: `ON` )
 * `-DBUILD_SHARED_LIBS=OFF`
    * Create static libraries instead of shared libraries
+* `-DBUILD_STRICT=OFF`
+   * Don't treat compile warnings as build errors (default: `ON` )
 * `-DCMAKE_PREFIX_PATH=<installation directory>`
    * Indicate prerequiste installation directory (ex. yakushima)
 * `-DFORMAT_FILES_WITH_CLANG_FORMAT_BEFORE_EACH_BUILD=ON`

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -164,6 +164,11 @@ endif ()
 # End : parameter settings
 
 function(set_compile_options target_name)
-    target_compile_options(${target_name}
+    if (BUILD_STRICT)
+        target_compile_options(${target_name}
             PRIVATE -Wall -Wextra -Werror)
+    else()
+        target_compile_options(${target_name}
+            PRIVATE -Wall -Wextra)
+    endif()
 endfunction(set_compile_options)


### PR DESCRIPTION
Introduced a new `BUILD_STRICT` CMake option to enable strict compilation settings ( with `-Werror` ).
By default, this option is enabled but can be turned off by `-DBUILD_STRICT=OFF`

This PR also enable to specify CMake build option on CI Workflow for workflow_dispatch via `inputs.cmake_build_option`
