### PR TITLE
optimize index recovery; reduce enter/leave and vector operation

### DIFF
--- a/src/datastore/limestone/datastore.cpp
+++ b/src/datastore/limestone/datastore.cpp
@@ -50,6 +50,12 @@ void recovery_from_datastore() {
 
     auto cursor = ss->get_cursor();
     SequenceId max_id{0};
+    Storage prev_st{storage::dummy_storage};
+
+    Token token{};
+    // acquire tx handle
+    while (enter(token) != Status::OK) { _mm_pause(); }
+
     while (cursor->next()) { // the next body is none.
         Storage st{cursor->storage()};
         std::string key{};
@@ -57,8 +63,7 @@ void recovery_from_datastore() {
         cursor->key(key);
         cursor->value(val);
         // prepare function updating information
-        auto put_data = [](Storage st, std::string_view key,
-                           std::string_view val) {
+        auto put_data = [&token](Storage st, std::string_view key, std::string_view val) {
             // check record existence
             Record* rec_ptr{};
             if (Status::OK == get<Record>(st, key, rec_ptr)) {
@@ -78,9 +83,6 @@ void recovery_from_datastore() {
                 // set tid
                 rec_ptr->set_tid(new_tid);
                 // put contents to tree
-                Token token{};
-                // acquire tx handle
-                while (enter(token) != Status::OK) { _mm_pause(); }
                 yakushima::node_version64* dummy{};
                 auto rc = put<Record>(
                         static_cast<session*>(token)->get_yakushima_token(), st,
@@ -90,8 +92,6 @@ void recovery_from_datastore() {
                     LOG_FIRST_N(ERROR, 1) << log_location_prefix
                                           << "unreachable path: " << rc;
                 }
-                // cleanup
-                leave(token);
             }
         };
         // check storage
@@ -180,11 +180,17 @@ void recovery_from_datastore() {
                 return;
             }
         } else {
-            shirakami::storage::register_storage(st); // maybe already exist
-            st_list.emplace_back(st);
+            if (st != prev_st) {
+                shirakami::storage::register_storage(st); // maybe already exist
+                st_list.emplace_back(st);
+            }
             put_data(st, key, val);
         }
+        prev_st = st;
     }
+    // cleanup
+    leave(token);
+
     if (max_id > 0) {
         // recovery sequence id generator
         sequence::id_generator_ctr().store(max_id + 1,


### PR DESCRIPTION
index 復元処理の並列化を検討していますが、そこでの修正が現在の直列実行に対しても効果があったので反映 (バックポート) します。

関連案件: project-tsurugi/tsurugi-issues/issues/1239
上記案件では、直列実行で 4億レコードの復元時に 数% の時間短縮がありました。

要点
* enter / leave 頻度が多いので減らす
    * 並列版では、大きな並行競合になる
* 1エントリ読むたびに storage を作ることを試し (既にあるので失敗する) 、また storage id を std::vector に記憶する(後で unique 処理でつぶす) が無駄なので、連続する storage の場合は飛ばす
    * storage を作ることを試す際に yakushima enter/leave をするがこれが並列版では、大きな並行競合になる
