### PR TITLE
change the return value of delete_record when deleting WSO DELETE

### DIFF
--- a/src/concurrency_control/interface/delete.cpp
+++ b/src/concurrency_control/interface/delete.cpp
@@ -55,7 +55,7 @@ inline Status process_after_write(session* ti, write_set_obj* wso) {
     }
     if (wso->get_op() == OP_TYPE::DELETE) {
         // delete operation already registered read for ltx
-        return Status::OK;
+        return Status::WARN_NOT_FOUND;
     }
     if (wso->get_op() == OP_TYPE::UPSERT) {
         auto rc = cancel_insert_if_tomb_stone(wso->get_rec_ptr());

--- a/test/concurrency_control/short_tx/delete/short_delete_after_delete_test.cpp
+++ b/test/concurrency_control/short_tx/delete/short_delete_after_delete_test.cpp
@@ -72,7 +72,7 @@ TEST_F(delete_after_delete, delete_after_delete_in_tx) { // NOLINT
     ASSERT_EQ(Status::OK,
               tx_begin({s, transaction_options::transaction_type::SHORT}));
     ASSERT_EQ(Status::OK, delete_record(s, st, k));
-    ASSERT_EQ(Status::OK, delete_record(s, st, k));
+    ASSERT_EQ(Status::WARN_NOT_FOUND, delete_record(s, st, k));
     ASSERT_EQ(Status::OK, commit(s));
     ASSERT_EQ(Status::OK, leave(s));
 }


### PR DESCRIPTION
delete_record を呼んだ際に対象の key 位置にレコードがない場合には WARN_NOT_FOUND を返します。
一方で、対象の key 位置にレコードが存在しているときに、同一トランザクション内でその位置に対して 2度 delete_record を実行すると 2回とも OK が返りますが、 read-your-own-writes 時な見え方では 1度目の delete_record の実行後にその位置のレコードは消えているので、先述の WARN_NOT_FOUND を返す通常の挙動との整合性が取れません。

2度目の delete_record では WARN_NOT_FOUND を返すように挙動を変更します。