### PR TITLE
不要な Record GC をしないようにする

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -34,3 +34,10 @@ Shirakami コードから参照する環境変数の説明
     * 未指定時、空文字列指定時には、デフォルト動作をする。
     * `SHIRAKAMI_RTX_DA_TERM_MUTEX=0` とすると、排他制御をしない。
     * `SHIRAKAMI_RTX_DA_TERM_MUTEX=1` とすると、排他制御をする。
+
+* `SHIRAKAMI_REDUCE_GC`
+  * Record GC の動作に関するフラグ。明白に Record GC する必要のない Storage に対しての Record GC をスキップする。
+  * デフォルト動作は Record GC をスキップをしない。
+    * 未指定時、空文字列指定時には、デフォルト動作をする。
+    * `SHIRAKAMI_REDUCE_GC=0` とすると、スキップをしない。
+    * `SHIRAKAMI_REDUCE_GC=1` とすると、スキップをする。

--- a/src/concurrency_control/garbage.cpp
+++ b/src/concurrency_control/garbage.cpp
@@ -182,12 +182,13 @@ inline Status unhooking_key(yakushima::Token ytk, Storage st, Record* rec_ptr) {
     check.set_obj(loadAcquire(rec_ptr->get_tidw_ref().get_obj()));
     // ====================
     // check before lock for reducing lock
-    // check timestamp whether it can unhook.
-    auto rc = check_unhooking_key_ts(check);
+    // check before w lock
+    Status rc{};
+    rc = check_unhooking_key_state(check);
     if (rc != Status::OK) { return rc; }
 
-    // check before w lock
-    rc = check_unhooking_key_state(check);
+    // check timestamp whether it can unhook.
+    rc = check_unhooking_key_ts(check);
     if (rc != Status::OK) { return rc; }
     // ====================
 
@@ -199,13 +200,13 @@ inline Status unhooking_key(yakushima::Token ytk, Storage st, Record* rec_ptr) {
     // ====================
     // main check after lock
     // check after w lock
-    rc = check_unhooking_key_ts(check);
+    rc = check_unhooking_key_state(check);
     if (rc != Status::OK) {
         rec_ptr->get_tidw_ref().unlock();
         return rc;
     }
 
-    rc = check_unhooking_key_state(check);
+    rc = check_unhooking_key_ts(check);
     if (rc != Status::OK) {
         rec_ptr->get_tidw_ref().unlock();
         return rc;

--- a/src/concurrency_control/include/garbage.h
+++ b/src/concurrency_control/include/garbage.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <thread>
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 #include "concurrent_queue.h"
@@ -71,6 +73,24 @@ using stats_info_type =
  */
 [[maybe_unused]] inline std::atomic<std::uint64_t> gc_ct_ver_{0};
 
+// hot/cold manage
+/**
+ * @brief data set (per storage) for hot/cold manage
+ */
+struct alignas(CACHE_LINE_SIZE) storage_stats {
+    std::atomic_bool worth_to_gc;
+};
+
+/**
+ * @brief marks "dirty" for a storage
+ */
+[[maybe_unused]] void set_dirty(Storage st);
+
+[[maybe_unused]] static void set_dirty(const std::unordered_set<Storage>& sts) {
+    for (auto&& st : sts) {
+        set_dirty(st);
+    }
+}
 
 // container for gc
 /**

--- a/src/concurrency_control/include/garbage.h
+++ b/src/concurrency_control/include/garbage.h
@@ -92,6 +92,8 @@ struct alignas(CACHE_LINE_SIZE) storage_stats {
     }
 }
 
+[[maybe_unused]] inline bool envflag_reduce_gc_{};
+
 // container for gc
 /**
  * @brief container of records which was unhooked from index.

--- a/src/concurrency_control/include/wp.h
+++ b/src/concurrency_control/include/wp.h
@@ -16,6 +16,7 @@
 #include "cpu.h"
 
 #include "concurrency_control/include/epoch.h"
+#include "concurrency_control/include/garbage.h"
 #include "concurrency_control/include/read_by.h"
 #include "concurrency_control/include/wp_lock.h"
 #include "concurrency_control/include/wp_meta.h"
@@ -48,11 +49,14 @@ public:
 
     wp_meta* get_wp_meta_ptr() { return &wp_meta_; }
 
+    garbage::storage_stats* get_storage_stats_ptr() { return &storage_stats_; }
+
 private:
     storage_option storage_option_{};
     range_read_by_long range_read_by_long_{};
     range_read_by_short range_read_by_short_{};
     wp_meta wp_meta_{};
+    garbage::storage_stats storage_stats_{};
 };
 
 constexpr Storage initial_page_set_meta_storage{};

--- a/src/concurrency_control/interface/long_tx/termination.cpp
+++ b/src/concurrency_control/interface/long_tx/termination.cpp
@@ -297,10 +297,10 @@ static inline void expose_local_write(
         return Status::OK;
     };
 
-#ifdef PWAL
-    std::unique_lock<std::mutex> lk{ti->get_lpwal_handle().get_mtx_logs()};
-#endif
     {
+#ifdef PWAL
+        std::unique_lock<std::mutex> lk0{ti->get_lpwal_handle().get_mtx_logs()};
+#endif
         std::shared_lock<std::shared_mutex> lk{ti->get_write_set().get_mtx()};
         for (auto&& wso : ti->get_write_set().get_ref_cont_for_bt()) {
             std::string_view pkey_view =

--- a/src/concurrency_control/interface/long_tx/termination.cpp
+++ b/src/concurrency_control/interface/long_tx/termination.cpp
@@ -27,7 +27,8 @@ namespace shirakami::long_tx {
 // ==============================
 // static inline functions for this source
 static inline void cancel_flag_inserted_records(session* const ti) {
-    auto process = [](std::pair<Record* const, write_set_obj>& wse) {
+    std::unordered_set<Storage> dirty{};
+    auto process = [&dirty](std::pair<Record* const, write_set_obj>& wse) {
         auto&& wso = std::get<1>(wse);
         if (wso.get_op() == OP_TYPE::INSERT ||
             wso.get_op() == OP_TYPE::UPSERT) {
@@ -65,6 +66,7 @@ static inline void cancel_flag_inserted_records(session* const ti) {
                     tid.set_lock(false);
                     tid.set_epoch(check.get_epoch());
                     rec_ptr->set_tid(tid); // and unlock
+                    dirty.insert(wso.get_storage());
                 } else {
                     rec_ptr->get_tidw_ref().unlock();
                 }
@@ -76,6 +78,7 @@ static inline void cancel_flag_inserted_records(session* const ti) {
     for (auto&& wso : ti->get_write_set().get_ref_cont_for_bt()) {
         process(wso);
     }
+    garbage::set_dirty(dirty);
 }
 
 static inline void compute_tid(session* ti, tid_word& ctid) {
@@ -96,11 +99,14 @@ static inline void expose_local_write(
 
     //bool should_backward{ti->is_write_only_ltx_now()};
     bool should_backward{!ti->get_is_forwarding()};
-    auto process = [ti, should_backward](
+
+    std::unordered_set<Storage> dirty{};
+    auto process = [ti, should_backward, &dirty](
                            std::pair<Record* const, write_set_obj>& wse,
                            tid_word ctid) {
         auto* rec_ptr = std::get<0>(wse);
         auto&& wso = std::get<1>(wse);
+        dirty.insert(wso.get_storage());
         [[maybe_unused]] bool should_log{true};
         // bw can backward including occ bw
         switch (wso.get_op()) {
@@ -325,6 +331,7 @@ static inline void expose_local_write(
             process(wso, ctid);
         }
     }
+    garbage::set_dirty(dirty);
 }
 
 static inline void register_wp_result_and_remove_wps(

--- a/src/concurrency_control/interface/short_tx/termination.cpp
+++ b/src/concurrency_control/interface/short_tx/termination.cpp
@@ -626,10 +626,10 @@ Status write_phase(session* ti, epoch::epoch_t ce) {
         return Status::OK;
     };
 
-#ifdef PWAL
-    std::unique_lock<std::mutex> lk{ti->get_lpwal_handle().get_mtx_logs()};
-#endif
     {
+#ifdef PWAL
+        std::unique_lock<std::mutex> lk0{ti->get_lpwal_handle().get_mtx_logs()};
+#endif
         std::shared_lock<std::shared_mutex> lk{ti->get_write_set().get_mtx()};
         if (ti->get_write_set().get_for_batch()) {
             for (auto&& itr : ti->get_write_set().get_ref_cont_for_bt()) {

--- a/src/concurrency_control/interface/short_tx/termination.cpp
+++ b/src/concurrency_control/interface/short_tx/termination.cpp
@@ -90,7 +90,8 @@ void unlock_records(session* const ti, std::size_t num_locked) {
  * This is called by only abort function
  */
 void change_inserting_records_state(session* const ti) {
-    auto process = [](write_set_obj* wso_ptr) {
+    std::unordered_set<Storage> dirty{};
+    auto process = [&dirty](write_set_obj* wso_ptr) {
         Record* rec_ptr = wso_ptr->get_rec_ptr();
         if (wso_ptr->get_op() == OP_TYPE::INSERT ||
             wso_ptr->get_op() == OP_TYPE::UPSERT) {
@@ -139,6 +140,7 @@ void change_inserting_records_state(session* const ti) {
                     tid.set_epoch(check.get_epoch());
                     tid.set_tid(check.get_tid());
                     rec_ptr->set_tid(tid); // and unlock
+                    dirty.insert(wso_ptr->get_storage());
                 } else {
                     // some operations interrupt and this is normal state.
                     rec_ptr->get_tidw_ref().unlock();
@@ -158,6 +160,7 @@ void change_inserting_records_state(session* const ti) {
             }
         }
     }
+    garbage::set_dirty(dirty);
 }
 // ==========
 
@@ -464,13 +467,15 @@ Status write_lock(session* ti, tid_word& commit_tid) {
 }
 
 Status write_phase(session* ti, epoch::epoch_t ce) {
-    auto process = [ti, ce](write_set_obj* wso_ptr) {
+    std::unordered_set<Storage> dirty{};
+    auto process = [ti, ce, &dirty](write_set_obj* wso_ptr) {
         tid_word update_tid{ti->get_mrc_tid()};
         VLOG(log_trace) << "write. op type: " << wso_ptr->get_op() << ", key: "
                         << shirakami_binstring(
                                    wso_ptr->get_rec_ptr()->get_key_view())
                         << ", value: "
                         << shirakami_binstring(wso_ptr->get_value_view());
+        dirty.insert(wso_ptr->get_storage());
         switch (wso_ptr->get_op()) {
             case OP_TYPE::UPSERT:
             case OP_TYPE::INSERT: {
@@ -651,6 +656,7 @@ Status write_phase(session* ti, epoch::epoch_t ce) {
             }
         }
     }
+    garbage::set_dirty(dirty);
 
     return Status::OK;
 }


### PR DESCRIPTION
Record GC スレッドは全 Storage に対して full scan し、全 Record オブジェクトを検査して回っているため、全く更新がなかった領域に対しても走査をし続けることになりますが、無駄な処理です。
1回の走査を終えると 1epoch スリープしますが、データ量が多い場合には 1走査が何十秒あるいはそれ以上になりスリープしている時間の割合はごくわずかで、大量のメモリ読み込みをし続けていることになります。

これを Storage 単位で更新の有無を記録し、更新がなかった範囲に対しては Record GC で走査しないようにして、無駄な処理を削減します。

関連案件: project-tsurugi/tsurugi-issues#1280

試験的機能のため、環境変数により動作のオンオフを決定し、
デフォルト動作では従来どおりの全走査挙動をするようにしてあります。