### PR TITLE
improve log messages related with mixed ddl/dml

### DIFF
--- a/src/concurrency_control/interface/delete.cpp
+++ b/src/concurrency_control/interface/delete.cpp
@@ -105,10 +105,10 @@ static void process_before_return_not_found(session* const ti,
         wp::page_set_meta* psm{};
         auto rc = wp::find_page_set_meta(storage, psm);
         if (rc != Status::OK) {
-            LOG_FIRST_N(ERROR, 1)
-                    << log_location_prefix
-                    << "unexpected error. library programming error or "
-                       "usage error (mixed ddl and dml?)";
+            LOG(ERROR) << log_location_prefix
+                       << "unexpected error. library programming error or "
+                          "usage error (mixed ddl and dml?)"
+                       << " rc:" << rc;
             return;
         }
         // get range read  by info

--- a/src/concurrency_control/interface/long_tx/helper.cpp
+++ b/src/concurrency_control/interface/long_tx/helper.cpp
@@ -83,8 +83,11 @@ void update_wp_at_commit(session* const ti) {
             // check the ptr was not changed
             (ret == Status::OK &&
              itr->second != target_psm_ptr->get_wp_meta_ptr())) {
-            LOG_FIRST_N(ERROR, 1) << log_location_prefix
-                                  << "Error. Suspected mix of DML and DDL";
+            LOG(ERROR) << log_location_prefix
+                       << "Error. Suspected mix of DML and DDL"
+                       << " ret:" << ret
+                       << " itr->second:" << itr->second
+                       << " target_psm_ptr->get_wp_meta_ptr():" << target_psm_ptr->get_wp_meta_ptr();
             ++itr;
             continue;
         }

--- a/src/concurrency_control/interface/long_tx/termination.cpp
+++ b/src/concurrency_control/interface/long_tx/termination.cpp
@@ -346,8 +346,11 @@ static inline void register_wp_result_and_remove_wps(
             // check the ptr was not changed
             (ret == Status::OK &&
              elem.second != target_psm_ptr->get_wp_meta_ptr())) {
-            LOG_FIRST_N(ERROR, 1) << log_location_prefix
-                                  << "Error. Suspected mix of DML and DDL";
+            LOG(ERROR) << log_location_prefix
+                       << "Error. Suspected mix of DML and DDL"
+                       << " ret:" << ret
+                       << " elem.second:" << elem.second
+                       << " target_psm_ptr->get_wp_meta_ptr():" << target_psm_ptr->get_wp_meta_ptr();
             continue;
         }
 

--- a/src/concurrency_control/interface/short_tx/termination.cpp
+++ b/src/concurrency_control/interface/short_tx/termination.cpp
@@ -218,10 +218,10 @@ static Status wp_verify(Storage const st, epoch::epoch_t const commit_epoch) {
     wp::wp_meta* wm{};
     auto rc{find_wp_meta(st, wm)};
     if (rc != Status::OK) {
-        LOG_FIRST_N(ERROR, 1)
-                << log_location_prefix
-                << "unreachable path. It strongly suspect that DML and DDL "
-                   "are mixed.";
+        LOG(ERROR) << log_location_prefix
+                   << "unreachable path. It strongly suspect that DML and DDL "
+                      "are mixed."
+                   << " rc:" << rc;
     }
     auto wps{wm->get_wped()};
     auto find_min_ep{wp::wp_meta::find_min_ep(wps)};

--- a/src/concurrency_control/interface/update.cpp
+++ b/src/concurrency_control/interface/update.cpp
@@ -31,9 +31,10 @@ static void process_before_return_not_found(session* const ti,
         wp::page_set_meta* psm{};
         auto rc = wp::find_page_set_meta(storage, psm);
         if (rc != Status::OK) {
-            LOG_FIRST_N(ERROR, 1) << log_location_prefix
-                                  << "library programming error or"
-                                     "usage error (mixed dml and ddl?)";
+            LOG(ERROR) << log_location_prefix
+                       << "library programming error or "
+                          "usage error (mixed dml and ddl?)"
+                       << " rc:" << rc;
             return;
         }
         // get range read  by info


### PR DESCRIPTION
https://github.com/project-tsurugi/tsurugi-issues/issues/177#issuecomment-4416668480 の内容に対応します。

下記メッセージのようにメッセージ `Suspected mix of DML and DDL` を `LOG(ERROR)` で出力し、関連するステータスコードや変数を出力します。

```
E20260513 22:37:36.587977 3086046 helper.cpp:86] /:shirakami Error. Suspected mix of DML and DDL ret:WARN_NOT_FOUND itr->second:0x52200000a980 target_psm_ptr->get_wp_meta_ptr():0x80
```